### PR TITLE
fix Read.me mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ module.exports = {
 
         var arg1 = 10;
         var arg2 = 20;
-        var add = controller.model.foo.bar.add(arg1, arg2);  // == 30
+        var res = controller.model.foo.bar.add(arg1, arg2);  // == 30
 
         var params = {
             arg1: arg1,
             arg2: arg2,
-            add: add
+            res: res
         };
 
         await controller.render('foo/foo.html', params);
@@ -124,7 +124,7 @@ module.exports = {
 #### App/view/foo/foo.html / foo/foo.html
 
 ```HTML
-<p>{{arg1}} + {{arg2}} = <strong>{{add}}</strong></p>
+<p>{{arg1}} + {{arg2}} = <strong>{{res}}</strong></p>
 ```
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ module.exports = {
 #### App/view/foo/foo.html / foo/foo.html
 
 ```HTML
-<p>{{arg1} + {{arg2}} = <strong>{{add}}</strong></p>
+<p>{{arg1}} + {{arg2}} = <strong>{{add}}</strong></p>
 ```
 
 ### Install


### PR DESCRIPTION
I found two bug
FIrst, one is in Read.me and fixed it, but the other can't be fixed in foo.html

`<p>{{arg1}} + {{arg2}} = <strong>{{add}}</strong></p>
`

Above, I can't see {{add}} value in browser. When I change the 'add' name to other name in controller, I can see it in browser

For example, I changed add to result.
**App/controller/foo/bar/index.js** 
```
        var arg1 = 10;
        var arg2 = 20;
        var result = controller.model.bbs.add(arg1, arg2);  // == 30

        var params = {
            arg1: arg1,
            arg2: arg2,
            result: result
        };
```

**App/view/foo/foo.html / foo/foo.html**
```
<p>{{arg1}} + {{arg2}} = <strong>{{result}}</strong></p>
```

 
