### PR TITLE
Fix _/__ for async, fix helper, no find-port-sync

### DIFF
--- a/lib/cache/driver/redis.js
+++ b/lib/cache/driver/redis.js
@@ -18,7 +18,7 @@ module.exports = {
     const tran = conn.multi();
     tran.get(key);
 
-    if (typeof (ttl) === 'number') {
+    if (typeof ttl === 'number') {
       tran.expire(key, ttl);
     }
 
@@ -29,7 +29,7 @@ module.exports = {
     const tran = conn.multi();
     tran.set(key, driver.payload.stringify(val));
 
-    if (typeof (ttl) === 'number') {
+    if (typeof ttl === 'number') {
       tran.expire(key, ttl);
     }
 

--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -1,7 +1,7 @@
 module.exports = (driver, connection) => {
   let cacheDriver;
 
-  if (typeof (driver) === 'object') {
+  if (typeof driver === 'object') {
     cacheDriver = driver;
   } else if (driver === 'redis') {
     cacheDriver = require('./driver/redis'); // eslint-disable-line global-require

--- a/lib/controller/index.js
+++ b/lib/controller/index.js
@@ -13,7 +13,7 @@ module.exports = {
         console.error('-------'); // eslint-disable-line no-console
       }
 
-      if (typeof (config.handler.error) === 'function') {
+      if (typeof config.handler.error === 'function') {
         config.handler.error(controller, err, statusCode);
       } else {
         res.status(statusCode || 500).send('An error has occurred.');
@@ -112,10 +112,7 @@ module.exports = {
         if (res.isDoNotUseFinishBuffer) {
           res.status(code).send(body);
         } else {
-          res.buffer = {
-            code,
-            body,
-          };
+          res.buffer = { code, body };
         }
       },
       render: (view, params, opts) => (

--- a/lib/controller/library/pagination.js
+++ b/lib/controller/library/pagination.js
@@ -19,10 +19,10 @@ module.exports = (req, res, opts, addOpts) => {
   /* eslint-disable no-param-reassign */
 
   if (opts && opts.count === undefined) {
-    if (typeof (opts[0]) === 'number'
-        && typeof (opts[1]) === 'object'
-        && typeof (opts[2]) === 'number'
-        && typeof (opts[3]) === 'number') {
+    if (typeof opts[0] === 'number'
+        && typeof opts[1] === 'object'
+        && typeof opts[2] === 'number'
+        && typeof opts[3] === 'number') {
       addOpts = addOpts || {};
       addOpts.count = opts[0]; // eslint-disable-line prefer-destructuring
       addOpts.page = opts[2]; // eslint-disable-line prefer-destructuring

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -6,7 +6,70 @@ const nonArrowFnRegex = /^\s*(?:class\s|(?:async)?(?:\s+function[\s*(]|(?:^|[*\s
  */
 
 const hasOwn = Object.prototype.hasOwnProperty;
-const isArrowFunction = fn => (typeof fn === 'function' && !hasOwn.call(fn, 'prototype') && !nonArrowFnRegex.test(String(fn)));
+const isArrowFunction = fn => (typeof fn === 'function' && !hasOwn.call(fn, 'prototype') && !nonArrowFnRegex.test(`${fn}`));
 const getRequireExt = name => Object.keys(require.extensions).find(x => name.endsWith(x));
+const applyPath = (baseParts, relParts) => {
+  const bp = baseParts;
+  let i = 0;
+  if (relParts.length > 1 && relParts[0] === '') {
+    bp.length = 2;
+    bp[0] = '';
+    bp[1] = '';
+    i = 1;
+  }
+  for (; i !== relParts.length; i += 1) {
+    const part = relParts[i];
+    const len = bp.length;
+    switch (part) {
+      case '': case '.': break;
+      case '..':
+        switch (len) {
+          case 0: break;
+          case 1:
+            if (bp[0] !== '' && bp[0] !== '..') {
+              bp[0] = '';
+              continue; // eslint-disable-line no-continue
+            }
+            break;
+          case 2:
+            if (bp[0] === '') {
+              bp[1] = '';
+              continue; // eslint-disable-line no-continue
+            }
+          /* fallthrough */
+          default:
+            if (bp[len - 1] !== '..') {
+              if (len === 1) bp[0] = '';
+              else bp.length = len - 1;
+              continue; // eslint-disable-line no-continue
+            }
+            break;
+        }
+      /* fallthrough */
+      default:
+        if (bp[len - 1] !== '') {
+          bp.length = len + 1;
+          bp[len] = part;
+        } else {
+          bp[len - 1] = part;
+        }
+        break;
+    }
+  }
+  if (relParts.length > 0 && relParts[relParts.length - 1] === '') {
+    const len = bp.length;
+    if (len === 0 || (len === 1 && bp[0] === '')) {
+      bp.length = 2;
+      bp[0] = '.';
+      bp[1] = '';
+    } else if (bp[len - 1] !== '') {
+      bp.length = len + 1;
+      bp[len] = '';
+    } else {
+      bp[len - 1] = '';
+    }
+  }
+  return bp;
+};
 
-module.exports = { isArrowFunction, getRequireExt };
+module.exports = { isArrowFunction, getRequireExt, applyPath };

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,8 +1,10 @@
 const loader = require('./loader');
 
 module.exports = (config) => {
-  const delegate = 'helper';
-  const loaded = loader(delegate, `${config.cfg.apppath}/helper`, config);
+  const delegate = {
+    helper: undefined,
+  };
+  const loaded = loader(delegate, `${config.cfg.apppath}/helper`);
   delegate.helper = loaded;
 
   return loaded;

--- a/lib/job.js
+++ b/lib/job.js
@@ -15,21 +15,20 @@ module.exports = (config) => {
   };
 
   const fail = (err) => {
-    if (typeof config.handler.error === 'function') {
-      const exit = getExitFunc(global.DP_NODE_JOB_UNCAUGHT_FATAL_EXCEPTION_CODE);
-      const errObj = new dpJobError(err); // eslint-disable-line new-cap
+    const { handler } = config;
+    if (typeof handler.error !== 'function') return null;
 
-      config.handler.error(asyncDp, errObj, null)
-        .then(exit, (e) => {
-          console.error(e); // eslint-disable-line no-console
-          return exit(e);
-        });
-    }
+    const exit = getExitFunc(global.DP_NODE_JOB_UNCAUGHT_FATAL_EXCEPTION_CODE);
+    const errObj = new dpJobError(err); // eslint-disable-line new-cap
+
+    return handler.error(asyncDp, errObj, null)
+      .then(exit, (e) => {
+        console.error(e); // eslint-disable-line no-console
+        return exit(e);
+      });
   };
 
-  return (delegate) => {
-    // No need to test whether delegate is an AsyncFunction
-    // since Promise joins (follows) them automatically
-    new Promise(resolve => resolve(delegate(asyncDp))).then(succ, fail);
-  };
+  // No need to test whether delegate is an AsyncFunction
+  // since Promise joins (follows) them automatically
+  return delegate => new Promise(resolve => resolve(delegate(asyncDp))).then(succ, fail);
 };

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,7 +4,8 @@ const decamelize = require('decamelize');
 const isCallable = require('is-callable');
 const { isArrowFunction } = require('./functions');
 
-const hasOwn = Object.prototype.hasOwnProperty;
+const { create, defineProperty, prototype: objProto } = Object;
+const hasOwn = objProto.hasOwnProperty;
 const nameVariationsOf = n => [n, camelize(n), decamelize(n)];
 
 const tryRequire = (pathloc, method) => {
@@ -35,27 +36,24 @@ const newVisibleRwPropDesc = value => ({
   configurable: true, enumerable: true, writable: true, value,
 });
 
-const isKey = n => (typeof n === 'string' || typeof n === 'symbol');
-const applyModule = (dest, owner, delegate, config, module) => (
-  Object.entries(module || {}).forEach(([name, orig]) => {
+const fnApply = Function.prototype.apply;
+const applyModule = (dest, owner, delegate, module) => {
+  const ctxProps = { _: newHiddenRoPropDesc(dest), __: newHiddenRoPropDesc(owner) };
+  return module && Object.entries(module).forEach(([name, orig]) => {
     let value = orig;
-
-    if (isCallable(value)) {
-      const isThisArrowFunction = isArrowFunction(orig);
-      value = (...args) => {
-        const that = isKey(delegate) ? config[delegate] : delegate;
-        that._ = dest;
-        that.__ = owner; // eslint-disable-line no-underscore-dangle
-
-        if (isThisArrowFunction) args.unshift(that);
-        return orig.apply(that, args);
-      };
+    if (isCallable(orig)) {
+      if (isArrowFunction(orig)) {
+        value = (...args) => orig(create(delegate, ctxProps), ...args);
+      } else {
+        const boundFn = fnApply.bind(orig);
+        value = (...args) => boundFn(create(delegate, ctxProps), args);
+      }
     }
+    return defineProperty(dest, name, newVisibleRwPropDesc(value)); // tail call
+  });
+};
 
-    Object.defineProperty(dest, name, newVisibleRwPropDesc(value));
-  }));
-
-const loadedProxies = Object.create(null);
+const loadedProxies = create(null);
 const parentRefPropDesc = (propName, pathloc) => {
   const idx = pathloc.lastIndexOf('/');
   const parentName = idx > 0 ? pathloc.substring(0, idx) : '/'.charAt(-idx);
@@ -68,16 +66,16 @@ const parentRefPropDesc = (propName, pathloc) => {
     get() {
       if (hasOwn.call(loadedProxies, parentName)) {
         const value = loadedProxies[parentName];
-        Object.defineProperty(this, propName, newHiddenRoPropDesc(value));
+        defineProperty(this, propName, newHiddenRoPropDesc(value));
         return value;
       }
       return undefined;
     },
   };
 };
-const loader = (delegate, pathloc, config) => {
+const loader = (delegate, pathloc) => {
   let loaded;
-  const proxy = new Proxy(Object.prototype, {
+  const proxy = new Proxy(objProto, {
     get(target, method, receiver) {
       if (method in target || typeof method !== 'string'
           || method.indexOf('/') !== -1) {
@@ -89,28 +87,26 @@ const loader = (delegate, pathloc, config) => {
       nameVariations.find((m) => {
         const loadRes = tryRequire(pathloc, m);
         const done = loadRes.module || hasOwn.call(loadRes, 'error');
-        if (done || (!load.found && loadRes.found)) {
-          load = loadRes;
-        }
+        if (done || (!load.found && loadRes.found)) load = loadRes;
         return done;
       });
       if (hasOwn.call(load, 'error')) throw load.error;
 
-      const subDir = (pathloc ? `${pathloc}/` : '') + load.method;
-      const result = loader(delegate, subDir, config);
-      applyModule(result, loaded, delegate, config, load.module);
+      const subDir = pathloc ? `${pathloc}/${load.method}` : load.method;
+      const result = loader(delegate, subDir);
+      applyModule(result, loaded, delegate, load.module);
 
       const resultDesc = newVisibleRwPropDesc(result);
-      nameVariations.forEach(m => Object.defineProperty(loaded, m, resultDesc));
+      nameVariations.forEach(m => defineProperty(loaded, m, resultDesc));
 
       return result;
     },
   });
 
   // Cache submodules by prototyping, plus lazy cacheing of '__'
-  loaded = Object.create(proxy, { __: parentRefPropDesc('__', pathloc) });
+  loaded = create(proxy, { __: parentRefPropDesc('__', pathloc) });
 
-  Object.defineProperty(loadedProxies, pathloc, newVisibleRwPropDesc(loaded));
+  defineProperty(loadedProxies, pathloc, newVisibleRwPropDesc(loaded));
   return loaded;
 };
 

--- a/lib/model/engine.js
+++ b/lib/model/engine.js
@@ -130,7 +130,7 @@ const db = {
   conn: (dsn) => {
     let key;
 
-    if (typeof (dsn) === 'string') {
+    if (typeof dsn === 'string') {
       key = dsn;
     } else if (dsn.key) {
       key = dsn.key; // eslint-disable-line prefer-destructuring

--- a/lib/model/index.js
+++ b/lib/model/index.js
@@ -12,6 +12,7 @@ module.exports = (config) => {
     paginate: engine.paginate,
     grouping: engine.grouping,
     helper: config.helper,
+    model: undefined,
   };
 
   // Assign engine when test mode enabled.

--- a/lib/router.js
+++ b/lib/router.js
@@ -8,72 +8,226 @@ const sessionLib = require('./controller/library/session');
 const cookieLib = require('./controller/library/cookie');
 const functions = require('./functions');
 
+const HTTP_METHODS = [
+  'checkout', 'copy', 'delete', 'get', 'head', 'lock', 'merge', 'mkactivity',
+  'mkcol', 'move', 'm-search', 'notify', 'options', 'patch', 'post', 'purge',
+  'put', 'report', 'search', 'subscribe', 'trace', 'unlock', 'unsubscribe',
+];
 const hasOwn = Object.prototype.hasOwnProperty;
 const isObject = x => (x && typeof x === 'object');
 const fn2Sngltn = a => (typeof a === 'function' ? [a] : a);
-const { getRequireExt } = functions;
+const propGetAlts = (o, ...keys) => {
+  if (typeof o === 'object' || typeof o === 'function') {
+    for (let i = 0; i !== keys.length; i += 1) {
+      const v = o[keys[i]];
+      if (typeof v !== 'undefined') return v;
+    }
+  }
+  return undefined;
+};
+const { getRequireExt, applyPath } = functions;
 const isArrowFunction = ((m, f) => (x) => {
   let v = m.get(x);
-  if (v == null) {
-    v = f(x);
-    m.set(x, v);
-  }
+  if (v == null) m.set(x, v = f(x));
   return v;
 })(new WeakMap(), functions.isArrowFunction);
-const applyPath = (baseParts, relParts) => {
-  const bp = baseParts;
-  if (relParts.length > 1 && relParts[0] === '') {
-    bp.length = 2;
-    bp[0] = '';
-    bp[1] = '';
-  }
-  for (let i = 0; i !== relParts.length; i += 1) {
-    const part = relParts[i];
-    const len = bp.length;
-    switch (part) {
-      case '': case '.':
-        break;
-      case '..':
-        switch (len) {
-          case 0:
-            break;
-          case 1:
-            if (bp[0] !== '' && bp[0] !== '..') {
-              bp[0] = '';
-              continue; // eslint-disable-line no-continue
-            }
-            break;
-          case 2:
-            if (bp[0] === '') {
-              bp[1] = '';
-              continue; // eslint-disable-line no-continue
-            }
-          /* fallthrough */
-          default:
-            if (bp[len - 1] !== '..') {
-              if (len === 1) bp[0] = '';
-              else bp.length = len - 1;
-              continue; // eslint-disable-line no-continue
-            }
-            break;
+
+const autoRegisterMiddlewares = (delegates, config) => {
+  const trees = [];
+  const configs = [];
+  const globalMiddlewaresFirst = [];
+  const globalMiddlewaresEnd = [];
+  const globalControllerFirst = [];
+  const globalControllerEnd = [];
+  const globalErrorHandler = [];
+
+  const findConfig = (path) => {
+    const item = configs.find(([p]) => path.startsWith(p));
+    return item ? item[1] : undefined;
+  };
+
+  const findMiddleware = (middlewares, path) => {
+    const item = middlewares.find(([p]) => (path.startsWith(p) && (
+      path.length === p.length || path.charAt(p.length) === '/')));
+    return item ? item[1] : undefined;
+  };
+
+  const specialMiddlewareFileNames = {
+    _: globalMiddlewaresFirst,
+    __: globalMiddlewaresEnd,
+    '.pre': globalControllerFirst,
+    '.post': globalControllerEnd,
+    '.err': globalErrorHandler,
+  };
+
+  const prepareInclude = (path, filePath, configParam, extension) => {
+    if (!fs.statSync(filePath).isFile()) return undefined;
+
+    const basename = filePath.substring(filePath.lastIndexOf('/') + 1);
+    const name = basename.substring(0, basename.length - extension.length);
+    if (hasOwn.call(specialMiddlewareFileNames, name)) {
+      const registry = specialMiddlewareFileNames[name];
+      // eslint-disable-next-line import/no-dynamic-require, global-require
+      let middleware = require(filePath);
+      if (name === '_' || name === '__') middleware = fn2Sngltn(middleware);
+      return registry.unshift([path.slice(0, -(name.length + 1)), middleware]); // tail call
+    }
+
+    const routes = require(filePath); // eslint-disable-line
+    const middlewareForGlobal = findMiddleware(globalMiddlewaresFirst, path);
+    const middlewareForGlobalEnd = findMiddleware(globalMiddlewaresEnd, path);
+    const controllerForGlobal = findMiddleware(globalControllerFirst, path);
+    const controllerForGlobalEnd = findMiddleware(globalControllerEnd, path);
+    const errorHandlerGlobal = findMiddleware(globalErrorHandler, path);
+
+    const replaceForAll = propGetAlts(routes, 'path', '_');
+    const middlewaresForAll = fn2Sngltn(propGetAlts(routes, 'middlewares', 'middleware', '__')) || middlewareForGlobal;
+    const controllerPrefixAll = controllerForGlobal && controllerForGlobal.all;
+    const controllerSuffixAll = controllerForGlobalEnd && controllerForGlobalEnd.all;
+
+    // tail call
+    return HTTP_METHODS.forEach((method) => {
+      if (typeof routes[method] !== 'function') return;
+
+      const suffix = propGetAlts(routes, `${method}Suffix`, `${method}_`); // getSuffix, get_
+      const middlewares = fn2Sngltn(propGetAlts(routes, `${method}Middlewares`, `${method}Middleware`, `_${method}_`)); // getMiddlewares, getMiddleware, _get_
+
+      const controllerPrefix = controllerForGlobal && (
+        controllerForGlobal[method] || controllerPrefixAll);
+      const controllerSuffix = controllerForGlobalEnd && (
+        controllerForGlobalEnd[method] || controllerSuffixAll);
+
+      let routePath = replaceForAll || propGetAlts(routes, `${method}Path`, `_${method}`); // getPath, _get
+      if (!routePath) {
+        routePath = path;
+      } else if (configParam && configParam.path) {
+        // replace path as specified in the effective .dp config
+        const { prefix } = configParam.path;
+        switch (prefix ? prefix.endsWith('/') + routePath.startsWith('/') : -1) {
+          case 0: routePath = `${prefix}/${routePath}`; break;
+          case 1: routePath = `${prefix}${routePath}`; break;
+          case 2: routePath = `${prefix}${routePath.substring(1)}`; break;
+          default: break;
         }
-      /* fallthrough */
-      default:
-        bp[bp[len - 1] !== '' ? len : len - 1] = part;
-        break;
+      }
+      if (suffix) routePath += suffix;
+
+      const middleware = middlewares || middlewaresForAll;
+
+      trees.push([
+        method,
+        routePath,
+        routes[method],
+        middleware,
+        middlewareForGlobalEnd,
+        controllerPrefix,
+        controllerSuffix,
+        errorHandlerGlobal,
+      ]);
+    });
+  };
+
+  const symConfigOriginPath = Symbol('dp-node.configOriginPath');
+
+  const traverse = (path, dirPath) => {
+    try {
+      if (!fs.statSync(dirPath).isDirectory()) return undefined;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      return console.error('Controller path load error, %s: %O', dirPath, e); // tail call
     }
-  }
-  if (relParts.length > 0 && relParts[relParts.length - 1] === '') {
-    const len = bp.length;
-    if (len === 0 || (len === 1 && bp[0] === '')) {
-      bp.length = 2;
-      bp[0] = '.';
-      bp[1] = '';
-    } else {
-      bp[bp[len - 1] !== '' ? len : len - 1] = '';
+
+    const fre = /^(?:[^.]|\.(?:dp|(?:pre|post|err)\.[^.]+)$)/;
+    const files = fs.readdirSync(dirPath).filter(RegExp.prototype.test.bind(fre));
+
+    const srf = RegExp.prototype.test.bind(/^_{0,2}\./);
+    files.sort((a, b) => !srf(a) - !srf(b) || (a > b) - (a < b));
+
+    // tail call
+    return files.forEach((name) => {
+      const fullPath = `${dirPath}/${name}`;
+
+      if (name === '.dp') {
+        // Configs
+        const dpIni = ini.parse(fs.readFileSync(fullPath, 'utf-8'));
+        Object.defineProperty(dpIni, symConfigOriginPath, {
+          configurable: true, enumerable: false, writable: false, value: path,
+        });
+
+        return configs.unshift([dirPath, dpIni]); // tail call
+      }
+
+      if (fs.statSync(fullPath).isDirectory()) {
+        return traverse(`${path}/${name}`, fullPath); // tail call
+      }
+
+      const ext = getRequireExt(name);
+      if (ext == null) return undefined;
+
+      const foundCfg = findConfig(dirPath);
+      const extlessName = name.substring(0, name.length - ext.length);
+      let subPath = path;
+      if (extlessName && extlessName !== 'index') subPath += `/${extlessName}`;
+
+      if (foundCfg && foundCfg.path) {
+        const { prefix } = foundCfg.path;
+        if (prefix) {
+          const spl = foundCfg[symConfigOriginPath].length;
+          const parts = subPath.substring(0, spl).split('/');
+          applyPath(parts, prefix.split('/'));
+          applyPath(parts, subPath.substring(spl + 1).split('/'));
+          if (parts[parts.length - 1] === '') parts.pop();
+          subPath = parts.join('/');
+        }
+      }
+
+      return prepareInclude(subPath, fullPath, foundCfg, ext); // tail call
+    });
+  };
+
+  traverse('', config.cfg.controller);
+
+  // More specific paths are first.
+  // /foo/bar is high priority than /foo
+  // /foo/bar is high priority than /foo/:type
+
+  const {
+    session, cookie, middlewarePostproc, route,
+  } = delegates;
+  trees.reduce(
+    (pps, e) => ((pps[+(e[1].indexOf(':') !== -1)].push(e), pps)),
+    [[], []] /* [ Only paths, Parameter paths ] */ // eslint-disable-line comma-dangle
+  ).forEach(paths => (
+    paths.sort(([a], [b]) => b.split('/').length - a.split('/').length || (b > a) - (b < a))
+      .forEach(e => route(...e))));
+
+  config.app.use((req, res, next) => { // eslint-disable-line no-unused-vars
+    const ctrl = controller.delegate(config, req, res, session, cookie);
+    const errorHandlerGlobal = findMiddleware(globalErrorHandler, req.url);
+
+    if (typeof errorHandlerGlobal !== 'function') {
+      // eslint-disable-next-line new-cap
+      controller.handler.serverError(ctrl, req, res, config, new dpError('404 Not Found', req), 404);
+      return;
     }
-  }
-  return bp;
+
+    new Promise((resolve) => {
+      const httpError = new createHttpError.NotFound();
+      httpError.code = 404;
+
+      resolve(errorHandlerGlobal(ctrl, httpError));
+    }).then((resp) => {
+      if (!res.buffer) res.buffer = { code: 404, body: resp || '404 Not Found' };
+
+      middlewarePostproc(req, res);
+    }, (e) => {
+      console.error(e); // eslint-disable-line no-console
+
+      const err = new dpError(e, req); // eslint-disable-line new-cap
+      err.message = '404 Not Found';
+      controller.handler.serverError(ctrl, req, res, config, err, 404);
+    }).catch(e => console.error(e)); // eslint-disable-line no-console
+  });
 };
 
 module.exports = (config) => {
@@ -92,7 +246,7 @@ module.exports = (config) => {
     global.__dpSessionEngine__ = session; // eslint-disable-line no-underscore-dangle
   }
 
-  const bodyParseRequired = { post: true, put: true, delete: true };
+  const bodyParseRequiredMethods = { post: true, put: true, delete: true };
   const bodyParserUrlEncoded = bodyParser.urlencoded(bodyParserUrlEncodedOpts);
 
   const handler = (delegate, req, res, data) => {
@@ -101,7 +255,7 @@ module.exports = (config) => {
     return Promise.resolve(delegate.apply(ctrl, args));
   };
 
-  const finalizeMiddleware = (req, res, next) => { // eslint-disable-line no-unused-vars
+  const middlewarePostproc = (req, res, next) => { // eslint-disable-line no-unused-vars
     if (res.bufferRedirect) {
       if (res.bufferRedirect.code) {
         res.redirect(res.bufferRedirect.url, res.bufferRedirect.code);
@@ -116,7 +270,10 @@ module.exports = (config) => {
   };
 
   const delegates = {
-    route: (
+    session,
+    cookie,
+    middlewarePostproc,
+    route(
       method,
       path,
       delegate,
@@ -125,17 +282,15 @@ module.exports = (config) => {
       controllerPrefix,
       controllerSuffix,
       controllerErrorHandler // eslint-disable-line comma-dangle
-    ) => {
-      let params = [path];
+    ) {
+      const params = [path];
 
-      if (hasOwn.call(bodyParseRequired, method)) {
-        params.push(bodyParserUrlEncoded);
-      }
+      if (hasOwn.call(bodyParseRequiredMethods, method)) params.push(bodyParserUrlEncoded);
 
       // Add middlewares
       if (isObject(middlewares) || isObject(middlewaresEnd)) {
         params.push((req, res, next) => {
-          const dp = async (callback) => {
+          const dp = (callback) => {
             const ctrl = controller.delegate(config, req, res, session, cookie);
             const handlerObj = {
               controller: ctrl,
@@ -143,11 +298,11 @@ module.exports = (config) => {
               model: config.model,
             };
 
-            try {
-              await (callback(handlerObj));
-            } catch (err) {
-              controller.handler.serverError(ctrl, req, res, config, new dpError(err, req), 500) // eslint-disable-line
-            }
+            return new Promise(resolve => resolve(callback(handlerObj)))
+              .catch((err) => {
+                const errObj = new dpError(err, req); // eslint-disable-line new-cap
+                return controller.handler.serverError(ctrl, req, res, config, errObj, 500);
+              });
           };
 
           req.async = dp;
@@ -158,300 +313,85 @@ module.exports = (config) => {
       }
 
       // Add middlewares
-      if (isObject(middlewares)) {
-        params = params.concat(middlewares);
-      }
+      if (isObject(middlewares)) params.push(middlewares);
 
-      const isAvailableMiddlewaresForEnd = isObject(middlewaresEnd);
+      const hasMiddlewaresEnd = isObject(middlewaresEnd);
 
       const symPrefix = Symbol('dp-node.prefix');
       const symBody = Symbol('dp-node.body');
 
-      const finalizeController = (req, res, next, done, resKey, error) => {
+      const controllerPostproc = (req, res, next, done, resKey, isHandlingError) => (
         done.then((resp) => {
-          if (typeof (res.buffer) === 'undefined' && resp) {
+          if (typeof res.buffer === 'undefined' && resp) {
             if (resKey) {
               res[resKey] = resp;
             } else {
               res.buffer = {
-                code: error ? 500 : 200,
+                code: isHandlingError ? 500 : 200,
                 body: resp,
               };
             }
-          } else if (resp === true && isAvailableMiddlewaresForEnd) {
-            finalizeMiddleware(req, res);
+          } else if (resp === true && hasMiddlewaresEnd) {
+            middlewarePostproc(req, res);
             return;
           }
 
           next();
         }).catch((err) => {
-          if (controllerErrorHandler && !error) {
+          if (controllerErrorHandler && !isHandlingError) {
             next(err);
             return;
           }
 
           const ctrl = controller.delegate(config, req, res, session, cookie);
-          controller.handler.serverError(ctrl, req, res, config, new dpError(err, req), 500) // eslint-disable-line
-        });
-      };
+          const error = new dpError(err, req); // eslint-disable-line new-cap
+          controller.handler.serverError(ctrl, req, res, config, error, 500);
+        }));
 
       if (controllerPrefix) {
         params.push((req, res, next) => {
           const done = handler(controllerPrefix, req, res);
-          finalizeController(req, res, next, done, symPrefix);
+          controllerPostproc(req, res, next, done, symPrefix);
         });
       }
 
       // Add action
       params.push((req, res, next) => {
         const done = handler(delegate, req, res, res[symPrefix]);
-        finalizeController(req, res, next, done, controllerSuffix ? symBody : null);
+        controllerPostproc(req, res, next, done, controllerSuffix ? symBody : null);
       });
 
       if (controllerSuffix) {
         params.push((req, res, next) => {
           const done = handler(controllerSuffix, req, res, res[symBody]);
-          finalizeController(req, res, next, done);
+          controllerPostproc(req, res, next, done);
         });
       }
 
       // Add middlewares for end
-      if (isAvailableMiddlewaresForEnd) {
-        params = params.concat(middlewaresEnd);
-      }
+      if (hasMiddlewaresEnd) params.push(middlewaresEnd);
 
       // Error handling on controller
       if (controllerErrorHandler) {
         params.push((err, req, res, next) => {
           const done = handler(controllerErrorHandler, req, res, err);
-          finalizeController(req, res, next, done, null, true);
+          controllerPostproc(req, res, next, done, null, true);
         });
       }
 
-      params.push(finalizeMiddleware);
-
-      // Error handling globally.
-      params.push((err, req, res, next) => { // eslint-disable-line no-unused-vars
+      // Postprocess and global error handling
+      // eslint-disable-next-line no-unused-vars
+      params.push(middlewarePostproc, (err, req, res, next) => {
         const ctrl = controller.delegate(config, req, res, session, cookie);
-        controller.handler.serverError(ctrl, req, res, config, new dpError(err, req), 500) // eslint-disable-line
+        const error = new dpError(err, req); // eslint-disable-line new-cap
+        controller.handler.serverError(ctrl, req, res, config, error, 500);
       });
 
       config.app[method](...params);
     },
   };
 
-  if (config.cfg.controller) {
-    const trees = [];
-    const configs = [];
-    const globalMiddlewaresFirst = [];
-    const globalMiddlewaresEnd = [];
-    const globalControllerFirst = [];
-    const globalControllerEnd = [];
-    const globalErrorHandler = [];
-
-    const findConfig = (path) => {
-      const item = configs.find(([p]) => path.startsWith(p));
-      return item ? item[1] : null;
-    };
-
-    const findMiddleware = (middlewares, path) => {
-      const item = middlewares.find(([p]) => (
-        path.startsWith(p) && (path.length === p.length || path.charAt(p.length) === '/')));
-      return item ? item[1] : null;
-    };
-
-    const specialMiddlewareFileNames = {
-      _: globalMiddlewaresFirst,
-      __: globalMiddlewaresEnd,
-      '.pre': globalControllerFirst,
-      '.post': globalControllerEnd,
-      '.err': globalErrorHandler,
-    };
-
-    const includePreapre = (path, filePath, configParam) => {
-      if (!fs.statSync(filePath).isFile()) {
-        return false;
-      }
-
-      const basename = filePath.substring(filePath.lastIndexOf('/') + 1);
-      const dotIdx = basename.lastIndexOf('.');
-      const name = dotIdx !== -1 ? basename.substring(0, dotIdx) : basename;
-      if (hasOwn.call(specialMiddlewareFileNames, name)) {
-        const registry = specialMiddlewareFileNames[name];
-        const middleware = require(filePath); // eslint-disable-line
-        registry.unshift([path.slice(0, -(name.length + 1)), middleware]);
-        return true;
-      }
-
-      const routes = require(filePath); // eslint-disable-line
-      const middlewareForGlobal = fn2Sngltn(findMiddleware(globalMiddlewaresFirst, path));
-      const middlewareForGlobalEnd = fn2Sngltn(findMiddleware(globalMiddlewaresEnd, path));
-      const controllerForGlobal = findMiddleware(globalControllerFirst, path);
-      const controllerForGlobalEnd = findMiddleware(globalControllerEnd, path);
-      const errorHandlerGlobal = findMiddleware(globalErrorHandler, path);
-      const methods = [
-        'checkout', 'copy', 'delete', 'get', 'head', 'lock', 'merge', 'mkactivity',
-        'mkcol', 'move', 'm-search', 'notify', 'options', 'patch', 'post', 'purge',
-        'put', 'report', 'search', 'subscribe', 'trace', 'unlock', 'unsubscribe',
-      ];
-
-      methods.forEach((method) => {
-        if (typeof routes[method] === 'function') {
-          const replaceAll = routes.path || routes._;
-          const replaceMethod = routes[`${method}Path`]
-                              || routes[`_${method}`]; // getPath, _get
-          const suffix = routes[`${method}Suffix`]
-                       || routes[`${method}_`]; // getSuffix, get_
-          const middlewaresForAll = fn2Sngltn(routes.middlewares
-                                  || routes.middleware
-                                  || routes.__); // eslint-disable-line no-underscore-dangle
-          const middlewares = fn2Sngltn(routes[`${method}Middlewares`]
-                            || routes[`${method}Middleware`]
-                            || routes[`_${method}_`]); // getMiddlewares, getMiddleware, _get_
-
-          const controllerPrefix = controllerForGlobal
-            ? (controllerForGlobal[method] || controllerForGlobal.all)
-            : null;
-          const controllerSuffix = controllerForGlobalEnd
-            ? (controllerForGlobalEnd[method] || controllerForGlobalEnd.all)
-            : null;
-
-          // replace url by .dp config
-          let routePath = replaceAll || replaceMethod;
-          if (!routePath) {
-            routePath = path;
-          } else if (configParam && configParam.path) {
-            const { prefix } = configParam.path;
-            if (prefix) {
-              routePath = (routePath.startsWith('/') ? prefix.slice(0, -1) : prefix) + routePath;
-            }
-          }
-          if (suffix) routePath += suffix;
-
-          const middleware = middlewares || middlewaresForAll || middlewareForGlobal;
-
-          trees.push([
-            method,
-            routePath,
-            routes[method],
-            middleware,
-            middlewareForGlobalEnd,
-            controllerPrefix,
-            controllerSuffix,
-            errorHandlerGlobal,
-          ]);
-        }
-      });
-
-      return true;
-    };
-
-    const traverse = (path, dirPath) => {
-      try {
-        if (!fs.statSync(dirPath).isDirectory()) {
-          return undefined;
-        }
-      } catch (_) {
-        // eslint-disable-next-line no-console
-        return console.error(`Controller path load error, ${dirPath}`); // tail call
-      }
-
-      const fre = /^(?:[^.]|\.(?:dp|(?:pre|post|err)\.[^.]+)$)/;
-      const files = fs.readdirSync(dirPath).filter(RegExp.prototype.test.bind(fre));
-
-      const srf = RegExp.prototype.test.bind(/^_{0,2}\./);
-      files.sort((a, b) => !srf(a) - !srf(b) || (a > b) - (a < b));
-
-      // tail call
-      return files.forEach((name) => {
-        const fullPath = `${dirPath}/${name}`;
-
-        if (name === '.dp') {
-          // Configs
-          const dpIni = ini.parse(fs.readFileSync(fullPath, 'utf-8'));
-          dpIni._ = path;
-
-          const pathSec = dpIni.path;
-          if (pathSec) {
-            const pfx = pathSec.prefix;
-            if (pfx && !pfx.endsWith('/')) pathSec.prefix = `${pfx}/`;
-          }
-
-          return configs.unshift([dirPath, dpIni]); // tail call
-        }
-
-        if (fs.statSync(fullPath).isDirectory()) {
-          return traverse(`${path}/${name}`, fullPath); // tail call
-        }
-        const ext = getRequireExt(name);
-        if (ext != null) {
-          const foundCfg = findConfig(dirPath);
-          let subPath = name !== `index${ext}` ? `${path}/${name.substr(0, name.lastIndexOf('.'))}` : path;
-
-          if (foundCfg && foundCfg.path) {
-            const { prefix } = foundCfg.path;
-            if (prefix) {
-              const spl = foundCfg._.length;
-              const parts = subPath.substring(0, spl).split('/');
-              applyPath(parts, prefix.split('/'));
-              parts.pop();
-              applyPath(parts, subPath.substring(spl + 1).split('/'));
-              if (parts[parts.length - 1] === '') parts.length -= 1;
-              subPath = parts.join('/');
-            }
-          }
-
-          return includePreapre(subPath, fullPath, foundCfg); // tail call
-        }
-        return undefined;
-      });
-    };
-
-    const includes = () => {
-      const pps = [[], []]; // [ Only paths, Parameter paths ]
-
-      // More specific paths are first.
-      // /foo/bar is high priority than /foo
-      // /foo/bar is high priority than /foo/:type
-
-      trees.forEach(e => pps[+(e[1].indexOf(':') !== -1)].push(e));
-      pps.forEach(paths => (
-        paths.sort(([a], [b]) => (b.split('/').length - a.split('/').length || (b > a) - (b < a)))
-          .forEach(e => delegates.route(...e))));
-    };
-
-    traverse('', config.cfg.controller);
-    includes();
-
-    config.app.use(async (req, res, next) => { // eslint-disable-line no-unused-vars
-      const ctrl = controller.delegate(config, req, res, session, cookie);
-
-      try {
-        const errorHandlerGlobal = findMiddleware(globalErrorHandler, req.url);
-
-        if (typeof errorHandlerGlobal === 'function') {
-          const httpError = new createHttpError.NotFound();
-          httpError.code = 404;
-
-          const resp = await errorHandlerGlobal(ctrl, httpError);
-
-          if (!res.buffer) {
-            res.buffer = {
-              code: 404,
-              body: resp || '404 Page Notfound',
-            };
-          }
-
-          finalizeMiddleware(req, res);
-          return;
-        }
-      } catch (e) {
-        console.error(e); // eslint-disable-line no-console
-      }
-
-      controller.handler.serverError(ctrl, req, res, config, new dpError('404 Page Notfound', req), 404) // eslint-disable-line
-    });
-  }
+  if (config.cfg.controller) autoRegisterMiddlewares(delegates, config);
 
   return delegates;
 };

--- a/lib/static/js/dp.helper.js
+++ b/lib/static/js/dp.helper.js
@@ -228,7 +228,7 @@ dp.helper = {
     }
 
     const finalize = function (data) {
-      if (data && typeof (data) === 'object') {
+      if (data && typeof data === 'object') {
         const finalizePage = function () {
           if (data.redirect) {
             document.location.href = data.redirect;

--- a/lib/static/js/dp.ui.js
+++ b/lib/static/js/dp.ui.js
@@ -38,7 +38,7 @@ dp.ui = {
       let _msg_html;
       const _buttons = [];
 
-      if (typeof (a) === 'object' && !b && !c && !d && !e) {
+      if (typeof a === 'object' && !b && !c && !d && !e) {
         if (a.message && a.html) {
           _msg_html = a.message;
         } else if (a.message) {
@@ -50,7 +50,7 @@ dp.ui = {
             _buttons.push([a.buttons[i][0], a.buttons[i][1]]);
           }
         }
-      } else if (typeof (a) === 'string' && !b && !c && !d && !e) {
+      } else if (typeof a === 'string' && !b && !c && !d && !e) {
         _msg = a;
 
         if (b === null) {
@@ -58,24 +58,24 @@ dp.ui = {
         } else {
           _buttons.push(['OK', undefined]);
         }
-      } else if (typeof (a) === 'string' && typeof (b) === 'string' && !c && !d && !e) {
+      } else if (typeof a === 'string' && typeof b === 'string' && !c && !d && !e) {
         _msg = a;
         _buttons.push([b, undefined]);
-      } else if (typeof (a) === 'string' && typeof (b) === 'function' && !c && !d && !e) {
+      } else if (typeof a === 'string' && typeof b === 'function' && !c && !d && !e) {
         _msg = a;
         _buttons.push(['OK', b]);
-      } else if (typeof (a) === 'string' && typeof (b) === 'function' && typeof (c) === 'string' && !d && !e) {
+      } else if (typeof a === 'string' && typeof b === 'function' && typeof c === 'string' && !d && !e) {
         _msg = a;
         _buttons.push([c, b]);
-      } else if (typeof (a) === 'string' && typeof (b) === 'function' && typeof (c) === 'function' && !d && !e) {
+      } else if (typeof a === 'string' && typeof b === 'function' && typeof c === 'function' && !d && !e) {
         _msg = a;
         _buttons.push(['OK', b]);
         _buttons.push(['Cancel', c]);
-      } else if (typeof (a) === 'string' && typeof (b) === 'function' && typeof (c) === 'string' && typeof (d) === 'function' && !e) {
+      } else if (typeof a === 'string' && typeof b === 'function' && typeof c === 'string' && typeof d === 'function' && !e) {
         _msg = a;
         _buttons.push([c, b]);
         _buttons.push(['Cancel', d]);
-      } else if (typeof (a) === 'string' && typeof (b) === 'function' && typeof (c) === 'string' && typeof (d) === 'function' && typeof (e) === 'string') {
+      } else if (typeof a === 'string' && typeof b === 'function' && typeof c === 'string' && typeof d === 'function' && typeof e === 'string') {
         _msg = a;
         _buttons.push([c, b]);
         _buttons.push([e, d]);
@@ -121,7 +121,7 @@ dp.ui = {
         btn.addClass(`_i-${k}`);
         btn.text(e[0]);
         btn.click(() => {
-          if (e[1] && typeof (e[1]) === 'function') {
+          if (e[1] && typeof e[1] === 'function') {
             delegate = e[1];
           }
 
@@ -196,7 +196,7 @@ dp.ui = {
                   delegate = eval(dp_jqlib(this).attr('dp-on-return'));
                 } catch (_) {}
 
-                if (delegate && typeof (delegate) === 'function') {
+                if (delegate && typeof delegate === 'function') {
                   dp_jqlib(this).attr('dp-on-return-busy', 'yes');
                   setTimeout(delegate(dp_jqlib(this)), 0);
                   setTimeout(`dp_jqlib('#${_id}').attr('dp-on-return-busy', 'no');`, 150);
@@ -222,7 +222,7 @@ dp.ui = {
                 delegate = eval(dp_jqlib(this).attr('dp-on-focus'));
               } catch (_) {}
 
-              if (delegate && typeof (delegate) === 'function') {
+              if (delegate && typeof delegate === 'function') {
                 setTimeout(delegate(dp_jqlib(this), e), 0);
               }
             });
@@ -243,7 +243,7 @@ dp.ui = {
                 delegate = eval(dp_jqlib(this).attr('dp-on-focusout'));
               } catch (_) {}
 
-              if (delegate && typeof (delegate) === 'function') {
+              if (delegate && typeof delegate === 'function') {
                 setTimeout(delegate(dp_jqlib(this), e), 0);
               }
             });
@@ -263,7 +263,7 @@ dp.ui = {
                 delegate = eval(dp_jqlib(this).attr('dp-on-keyup'));
               } catch (_) {}
 
-              if (delegate && typeof (delegate) === 'function') {
+              if (delegate && typeof delegate === 'function') {
                 setTimeout(delegate(dp_jqlib(this), e), 0);
               }
             });
@@ -283,7 +283,7 @@ dp.ui = {
                 delegate = eval(dp_jqlib(this).attr('dp-on-keydown'));
               } catch (_) {}
 
-              if (delegate && typeof (delegate) === 'function') {
+              if (delegate && typeof delegate === 'function') {
                 setTimeout(delegate(dp_jqlib(this), e), 0);
               }
             });
@@ -303,7 +303,7 @@ dp.ui = {
                 delegate = eval(dp_jqlib(this).attr('dp-on-paste'));
               } catch (_) {}
 
-              if (delegate && typeof (delegate) === 'function') {
+              if (delegate && typeof delegate === 'function') {
                 let clipboardData; let pastedData;
 
                 try {

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -2,15 +2,6 @@
 
 module.exports = {
   init() {
-    let port;
-
-    try {
-      port = require('find-port-sync')(); // eslint-disable-line
-    } catch (_) {
-      port = 62369;
-    }
-
-    global.DP_TEST_PORT = port;
     global.isTest = true;
 
     return (fn, app, title) => {
@@ -19,15 +10,20 @@ module.exports = {
       describe(title || 'WebServer', () => {
         let http;
 
-        before(() => { // eslint-disable-line no-undef
-          http = app.dp.listen(port);
+        before(() => new Promise((resolve) => { // eslint-disable-line no-undef
+          http = app.dp.listen();
 
           const engine = global.__dpModelEngine__;
           if (engine.destroyed) {
             engine.registerDsn(app.dp.config.cfg.databaseDsn);
             engine.destroyed = false;
           }
-        });
+
+          http.on('listening', () => {
+            global.DP_TEST_PORT = http.address().port;
+            resolve(undefined);
+          });
+        }));
 
         after(() => { // eslint-disable-line no-undef
           const modelEngine = global.__dpModelEngine__;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2115,15 +2115,6 @@
         }
       }
     },
-    "find-port-sync": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/find-port-sync/-/find-port-sync-1.1.1.tgz",
-      "integrity": "sha512-whP0lfxiPiuRm9BFQ8fcYGqJDBigZOxOkUy+QeSss5B1+8fC5MG31Hk3PDHnG1/LQeVUrYecpaElH7nUe5nLAA==",
-      "dev": true,
-      "requires": {
-        "get-port-cli": "^1.1.0"
-      }
-    },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -2848,22 +2839,6 @@
             "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-      "dev": true
-    },
-    "get-port-cli": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-port-cli/-/get-port-cli-1.1.0.tgz",
-      "integrity": "sha1-8zSxNpletS5aXVwQ48blnhipRu8=",
-      "dev": true,
-      "requires": {
-        "get-port": "^3.0.0",
-        "meow": "^3.4.2"
       }
     },
     "get-stdin": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint": "^5.9.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.7.0",
-    "find-port-sync": "^1.1.1",
     "mocha": "^5.2.0",
     "mysql": "^2.16.0",
     "nodemon": "^1.18.6",

--- a/test/example/controller/helper/delegate.js
+++ b/test/example/controller/helper/delegate.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+
+module.exports = {
+  async get() {
+    assert(this.helper.bar.qux() === 'qux');
+    assert(this.helper.bar.quux() === 'quux');
+    assert(this.helper.bar.moo() === 'moo');
+
+    return 'done';
+  },
+};

--- a/test/example/controller/model/prop.js
+++ b/test/example/controller/model/prop.js
@@ -11,6 +11,10 @@ module.exports = {
     assert(this.model.test.uscore.baz.koo() === 'koo');
     assert(this.model.test.uscore.foo.fao() === this.model.test.uscore.foo.far.fao);
     assert(this.model.test.uscore.one.inOne.two() === 'three');
+    assert(this.model.test.uscore.qux.fao() === this.model.test.uscore.foo.far.fao);
+    assert(this.model.test.uscore.qux.fred() === 'fred');
+    assert(this.model.test.uscore.qux.koo() === 'koo');
+    assert(this.model.test.uscore.qux.mos() === 'mos');
 
     return 'done';
   },

--- a/test/example/helper/bar.js
+++ b/test/example/helper/bar.js
@@ -1,11 +1,21 @@
 module.exports = {
   async barAsync() {
     return new Promise((resolve) => {
-      resolve(this.foo.bar());
+      resolve(this.__.foo.bar()); // eslint-disable-line no-underscore-dangle
     });
   },
-  bazAsync: async helper => helper.foo.baz(),
+  bazAsync: async helper => helper.__.foo.baz(), // eslint-disable-line no-underscore-dangle
   boz() {
-    return this.foo.boz;
+    return this.__.foo.boz; // eslint-disable-line no-underscore-dangle
+  },
+  qux() {
+    return this.helper.foo.qux();
+  },
+  quux() {
+    return this.helper.foo.quux;
+  },
+  meow: 'moo',
+  moo() {
+    return this.helper.bar.meow;
   },
 };

--- a/test/example/helper/foo.js
+++ b/test/example/helper/foo.js
@@ -4,4 +4,6 @@ module.exports = {
   },
   baz: () => 'baz',
   boz: 'boz',
+  qux: () => 'qux',
+  quux: 'quux',
 };

--- a/test/example/model/test/uscore/qux/index.js
+++ b/test/example/model/test/uscore/qux/index.js
@@ -1,0 +1,18 @@
+module.exports = {
+  fao() {
+    return this.__.foo.fao(); // eslint-disable-line no-underscore-dangle
+  },
+  fred() {
+    this._.quux.bark();
+    this.__.foo.fao(); // eslint-disable-line no-underscore-dangle
+    this.__.baz.koo(); // eslint-disable-line no-underscore-dangle
+    return this._.quux.fred;
+  },
+  koo() {
+    return this.__.baz.koo(); // eslint-disable-line no-underscore-dangle
+  },
+  mos() {
+    this.model.test.uscore.qux.fred(); // eslint-disable-line no-underscore-dangle
+    return this.__.qux.quux.mos; // eslint-disable-line no-underscore-dangle
+  },
+};

--- a/test/example/model/test/uscore/qux/quux.js
+++ b/test/example/model/test/uscore/qux/quux.js
@@ -1,0 +1,5 @@
+module.exports = {
+  fred: 'fred',
+  mos: 'mos',
+  bark: () => {},
+};

--- a/test/index.js
+++ b/test/index.js
@@ -223,6 +223,15 @@ require('../index').Tester.init()((req) => {
     });
   });
 
+  describe('Helper', () => {
+    it('Simple helper test.', (done) => {
+      req().get('/helper/simple').expect(200, 'done', done);
+    });
+    it('Helper delegate test.', (done) => {
+      req().get('/helper/delegate').expect(200, 'done', done);
+    });
+  });
+
   describe('Error Handling', () => {
     it('Response should be `This is an intended exception.`.', (done) => {
       req().get('/error/handler/throw_from_model?err=yes').expect(500, 'This is an intended exception.', done);


### PR DESCRIPTION
 * FIX: helper delegate was not properly assigned its loader
    (test cases included)
 * FIX: this._ and this.__ for loader functions was not reentrant
     - caused potential issues for async controller functions
     - Side-effect: delegate props are no longer mutable via such functions
    (test cases included)
 * Tests: Let OS probe for an available port at bind time
    (Removes dependency on find-port-sync)
 * Support using unix sockets and other addresses, not only HTTP
 * Attach original error to dpError in case error handler itself throws
 * Refactor lib/router.js: some then-internal APIs now available
    (This is so that the user could implement their own customized
     auto middleware registration)
 * Prefer ES6 object destructuring
 * Consistent typeof: typeof (x) ==> typeof x