### PR TITLE
Last PR: signPrefix conf, keepOnVerifyFail conf, loader fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,17 +114,22 @@ module.exports = (options) => {
   }
 
   if (defaultVal(options.session, {})) {
-    config.cfg.session = options.session || {};
-    config.cfg.session.secret = config.cfg.session.secret || 'dR@9oNp0W@r~NoD2';
-    config.cfg.session.volatility = defaultVal(config.cfg.session.volatility, false);
-    config.cfg.session.ttl = config.cfg.session.ttl || 3600 * 24 * 30;
+    const ns = options.session || {};
+    ns.secret = ns.secret || 'dR@9oNp0W@r~NoD2';
+    ns.volatility = defaultVal(ns.volatility, false);
+    ns.ttl = ns.ttl || 3600 * 24 * 30;
+    ns.signPrefix = ns.signPrefix || (options.cookie && options.cookie.signPrefix) || 's:';
+    config.cfg.session = ns;
   }
 
   if (defaultVal(options.cookie, {})) {
-    config.cfg.cookie = options.cookie || {};
-    config.cfg.cookie.secret = config.cfg.cookie.secret || 'dR@9oNp0W@r~Co0K2';
-    config.cfg.cookie.volatility = defaultVal(config.cfg.cookie.volatility, false);
-    config.cfg.cookie.ttl = config.cfg.cookie.ttl || 3600 * 24 * 30;
+    const ns = options.cookie || {};
+    ns.secret = ns.secret || 'dR@9oNp0W@r~Co0K2';
+    ns.volatility = defaultVal(ns.volatility, false);
+    ns.ttl = ns.ttl || 3600 * 24 * 30;
+    ns.signPrefix = ns.signPrefix || 's:';
+    ns.keepOnVerifyFail = ns.keepOnVerifyFail || false;
+    config.cfg.cookie = ns;
   }
 
   if (defaultVal(options.databaseDsn, [])) {
@@ -180,7 +185,7 @@ module.exports = (options) => {
     return require('./lib/job')(config); // eslint-disable-line global-require
   }
 
-  dp.app.dp = dp;
+  app.dp = dp;
   return app;
 };
 

--- a/lib/controller/library/cookie.js
+++ b/lib/controller/library/cookie.js
@@ -3,7 +3,7 @@ const signature = require('cookie-signature');
 module.exports = config => ({
   set: (req, res, key, val, opts) => {
     opts = opts || {}; // eslint-disable-line no-param-reassign
-    const signed = `s:${signature.sign(val || '', config.cfg.cookie.secret)}`;
+    const signed = `${config.cfg.cookie.signPrefix}${signature.sign(val || '', config.cfg.cookie.secret)}`;
 
     if (opts.expires === undefined) {
       if (config.cfg.cookie.volatility) {
@@ -21,13 +21,15 @@ module.exports = config => ({
     return true;
   },
   get: (req, res, key) => {
-    if (req.cookies[key]) {
+    const val = req.cookies[key];
+    const pfx = config.cfg.cookie.signPrefix;
+    if (val && val.startsWith(pfx)) {
       try {
-        const val = req.cookies[key];
-        if (val.slice(0, 2) !== 's:') return val;
-        return signature.unsign(val.slice(2), config.cfg.cookie.secret);
-      } catch (_) {} // eslint-disable-line no-empty
+        return signature.unsign(val.substring(pfx.length), config.cfg.cookie.secret);
+      } catch (_) {
+        if (!config.cfg.cookie.keepOnVerifyFail) return null;
+      }
     }
-    return null;
+    return val;
   },
 });

--- a/lib/controller/library/session.js
+++ b/lib/controller/library/session.js
@@ -25,7 +25,7 @@ module.exports = (config) => {
     if (sessionid) clearSessionId(req, res);
     sessionid = sessionid || uid(32); // eslint-disable-line no-param-reassign
 
-    const signed = `s:${signature.sign(sessionid, config.cfg.session.secret)}`;
+    const signed = `${config.cfg.session.signPrefix}${signature.sign(sessionid, config.cfg.session.secret)}`;
     let expires;
 
     if (config.cfg.session.volatility) {
@@ -53,11 +53,11 @@ module.exports = (config) => {
     let nsessionid;
 
     // Session ID from Signed Cookie
-    if (req.cookies[sessionIdKey]) {
+    const val = req.cookies[sessionIdKey];
+    const pfx = config.cfg.session.signPrefix;
+    if (val && val.startsWith(pfx)) {
       try {
-        let temp = req.cookies[sessionIdKey].slice(2);
-        temp = signature.unsign(temp, config.cfg.session.secret);
-        nsessionid = temp;
+        nsessionid = signature.unsign(val.substring(pfx), config.cfg.session.secret);
       } catch (_) { } // eslint-disable-line no-empty
     }
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,28 +1,29 @@
 const fs = require('fs');
+const path = require('path');
 const camelize = require('camelcase');
 const decamelize = require('decamelize');
 const isCallable = require('is-callable');
 const { isArrowFunction } = require('./functions');
 
-const { create, defineProperty, prototype: objProto } = Object;
-const hasOwn = objProto.hasOwnProperty;
+const hasOwn = Object.prototype.hasOwnProperty;
 const nameVariationsOf = n => [n, camelize(n), decamelize(n)];
 
 const tryRequire = (pathloc, method) => {
-  const joinedPath = pathloc ? `${pathloc}/${method}` : method;
+  const joinedPath = path.join(pathloc, method);
   try {
     // eslint-disable-next-line import/no-dynamic-require, global-require
     const module = require(joinedPath);
+    if (module == null) throw new Error(`require() returned null or undefined: ${joinedPath}`);
     return { module, method, found: true };
   } catch (e) { // watch out for non-Object (e.g. throw null) exceptions
     const res = { module: null, method, found: !e || e.code !== 'MODULE_NOT_FOUND' };
     if (res.found) {
-      res.error = e;
+      throw e;
     } else {
       try {
         res.found = fs.statSync(joinedPath).isDirectory();
       } catch (e1) {
-        if (!e1 || (e1.code !== 'ENOENT' && e1.code !== 'ELOOP')) res.error = e1;
+        if (!e1 || (e1.code !== 'ENOENT' && e1.code !== 'ELOOP')) throw e1;
       }
     }
     return res;
@@ -36,27 +37,19 @@ const newVisibleRwPropDesc = value => ({
   configurable: true, enumerable: true, writable: true, value,
 });
 
-const fnApply = Function.prototype.apply;
-const applyModule = (dest, owner, delegate, module) => {
-  const ctxProps = { _: newHiddenRoPropDesc(dest), __: newHiddenRoPropDesc(owner) };
-  return module && Object.entries(module).forEach(([name, orig]) => {
-    let value = orig;
-    if (isCallable(orig)) {
-      if (isArrowFunction(orig)) {
-        value = (...args) => orig(create(delegate, ctxProps), ...args);
-      } else {
-        const boundFn = fnApply.bind(orig);
-        value = (...args) => boundFn(create(delegate, ctxProps), args);
-      }
-    }
-    return defineProperty(dest, name, newVisibleRwPropDesc(value)); // tail call
-  });
-};
+const fnBind = Function.prototype.bind;
+/* eslint-disable comma-dangle */
+const applyModule = (dest, that, module) => (
+  Object.entries(module).forEach(([name, val]) => (
+    Object.defineProperty(dest, name, newVisibleRwPropDesc(
+      isCallable(val) ? fnBind.apply(val, isArrowFunction(val) ? [null, that] : [that]) : val
+    ))
+  ))
+);
+/* eslint-enable comma-dangle */
 
-const loadedProxies = create(null);
-const parentRefPropDesc = (propName, pathloc) => {
-  const idx = pathloc.lastIndexOf('/');
-  const parentName = idx > 0 ? pathloc.substring(0, idx) : '/'.charAt(-idx);
+const loadedProxies = Object.create(null);
+const parentRefPropDesc = (propName, parentName) => {
   if (hasOwn.call(loadedProxies, parentName)) {
     return newHiddenRoPropDesc(loadedProxies[parentName]);
   }
@@ -66,7 +59,7 @@ const parentRefPropDesc = (propName, pathloc) => {
     get() {
       if (hasOwn.call(loadedProxies, parentName)) {
         const value = loadedProxies[parentName];
-        defineProperty(this, propName, newHiddenRoPropDesc(value));
+        Object.defineProperty(this, propName, newHiddenRoPropDesc(value));
         return value;
       }
       return undefined;
@@ -75,38 +68,49 @@ const parentRefPropDesc = (propName, pathloc) => {
 };
 const loader = (delegate, pathloc) => {
   let loaded;
-  const proxy = new Proxy(objProto, {
+  const proxy = new Proxy(Object.prototype, {
     get(target, method, receiver) {
       if (method in target || typeof method !== 'string'
-          || method.indexOf('/') !== -1) {
+          || !method || method === '.' || method === '..'
+          || method.indexOf('/') !== -1
+          || (path.sep !== '/' && method.indexOf(path.sep) !== -1)) {
         return Reflect.get(target, method, receiver);
       }
       const nameVariations = nameVariationsOf(method);
 
       let load = { module: null, method, found: false };
-      nameVariations.find((m) => {
+      nameVariations.some((m) => {
         const loadRes = tryRequire(pathloc, m);
-        const done = loadRes.module || hasOwn.call(loadRes, 'error');
+        const done = loadRes.module != null;
         if (done || (!load.found && loadRes.found)) load = loadRes;
         return done;
       });
-      if (hasOwn.call(load, 'error')) throw load.error;
 
-      const subDir = pathloc ? `${pathloc}/${load.method}` : load.method;
+      const subDir = path.join(pathloc, load.method);
       const result = loader(delegate, subDir);
-      applyModule(result, loaded, delegate, load.module);
+      if (load.module != null) {
+        const that = Object.freeze(Object.create(delegate, {
+          _: {
+            configurable: false, enumerable: false, writable: false, value: result,
+          },
+          __: {
+            configurable: false, enumerable: false, writable: false, value: loaded,
+          },
+        }));
+        applyModule(result, that, load.module);
+      }
 
       const resultDesc = newVisibleRwPropDesc(result);
-      nameVariations.forEach(m => defineProperty(loaded, m, resultDesc));
+      nameVariations.forEach(m => Object.defineProperty(loaded, m, resultDesc));
 
       return result;
     },
   });
 
   // Cache submodules by prototyping, plus lazy cacheing of '__'
-  loaded = create(proxy, { __: parentRefPropDesc('__', pathloc) });
+  loaded = Object.create(proxy, { __: parentRefPropDesc('__', path.dirname(pathloc)) });
 
-  defineProperty(loadedProxies, pathloc, newVisibleRwPropDesc(loaded));
+  Object.defineProperty(loadedProxies, pathloc, newVisibleRwPropDesc(loaded));
   return loaded;
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2277,7 +2277,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2298,12 +2299,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2318,17 +2321,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2445,7 +2451,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2457,6 +2464,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2471,6 +2479,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2478,12 +2487,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2502,6 +2513,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2582,7 +2594,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2594,6 +2607,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2679,7 +2693,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2715,6 +2730,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2734,6 +2750,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2777,12 +2794,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
 * Make the 's:' prefix and verify failure behavioir configurable
 * loaded module methods is now bound on a constant object
   (method invocations no longer has non-native JS overhead)
 * Restored the 'path' module for non-Unix path separators
 * No more res.error, stack traces are captured on exception instantiation
   anyway.

Now I need to get back to work