### PR TITLE
use strict, cache ttl stable now(), rsv props supp

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
   "extends": "airbnb-base",
+  "parserOptions": {
+    "sourceType": "script"
+  },
   "env": {
     "jest": true
   },

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const express = require('express');
 const path = require('path');
 
@@ -47,10 +49,9 @@ module.exports = (options) => {
   const config = {};
 
   const defaultVal = (val, defVal) => (typeof val === 'undefined' ? defVal : val);
-  const arrayToObj = (arr, key) => (Array.isArray(arr) ? arr.reduce((acc, cur) => {
-    acc[cur[key]] = cur;
-    return acc;
-  }, {}) : arr);
+  const arrayToObj = (arr, key) => (Array.isArray(arr) ? arr.reduce((o, value) => (
+    Object.defineProperty(o, value[key], { configurable: true, enumerable: true, value })
+  ), {}) : arr);
 
   config.mode = (options.mode || 'web').toLowerCase();
   config.debug = defaultVal(options.debug, false);

--- a/lib/cache/driver/index.js
+++ b/lib/cache/driver/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-disable no-unused-vars */
 
 module.exports = {

--- a/lib/cache/driver/memory.js
+++ b/lib/cache/driver/memory.js
@@ -1,50 +1,50 @@
-const caches = {};
-const cacher = function Cacher() {
-  const values = {};
-  return {
-    get: (key) => {
-      const val = values[key];
-      if (!val) return undefined;
-      return !val.exp || val.exp > Date.now() ? val.val : null;
-    },
-    set: (key, val, ttl) => {
-      values[key] = {
-        val,
-        exp: ttl ? (Date.now() + (ttl * 1000)) : null,
-      };
-      return true;
-    },
-    del: (key) => {
-      delete values[key];
-      return true;
-    },
-    expire: (key, ttl) => {
-      const val = values[key];
-      if (!val || Date.now() >= val.exp) return false;
+'use strict';
 
-      val.exp = Date.now() + (ttl * 1000);
-      return ttl;
-    },
-    ttl: (key) => {
-      const val = values[key];
-      if (!val || Date.now() >= val.exp) return -1;
-
-      return (val.exp - Date.now()) / 1000;
-    },
-    close: () => {
-      Object.keys(values).forEach((e) => {
-        delete values[e];
-      });
-    },
+const { nextTick } = process;
+let lastNow = null;
+function now() {
+  if (lastNow == null) {
+    const ts = Date.now();
+    nextTick(() => { lastNow = null; });
+    lastNow = ts;
+  }
+  return lastNow;
+}
+function Cacher() {
+  let values = Object.create(null);
+  this.get = (key) => {
+    const val = values[key];
+    if (!val) return undefined;
+    return val.exp == null || val.exp > now() ? val.val : null;
   };
-};
+  this.set = (key, val, ttl) => {
+    const exp = ttl ? now() + ttl * 1e3 : null;
+    values[key] = { val, exp };
+    return true;
+  };
+  this.del = key => delete values[key];
+  this.expire = (key, ttl) => {
+    const val = values[key];
+    const ts = now();
+    if (!val || ts >= val.exp) return null;
 
+    val.exp = ts + (ttl * 1e3);
+    return ttl;
+  };
+  this.ttl = (key) => {
+    const val = values[key];
+    const ts = now();
+    return val && ts < val.exp ? (val.exp - ts) * 1e-3 : -1;
+  };
+  this.close = () => {
+    values = Object.create(null);
+  };
+}
+
+const caches = Object.create(null);
+/* eslint-disable no-return-assign */
 module.exports = {
-  conn: (connection, key) => {
-    if (caches[key]) return caches[key];
-    caches[key] = cacher();
-    return caches[key];
-  },
+  conn: (connection, key) => (key in caches ? caches[key] : (caches[key] = new Cacher())),
   get: (conn, key, ttl) => conn().get(key, ttl),
   set: (conn, key, val, ttl) => conn().set(key, val, ttl),
   del: (conn, key) => conn().del(key),

--- a/lib/cache/driver/redis.js
+++ b/lib/cache/driver/redis.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const redis = require('redis');
 const bluebird = require('bluebird');
 const driver = require('./index');
@@ -5,14 +7,12 @@ const driver = require('./index');
 bluebird.promisifyAll(redis.RedisClient.prototype);
 bluebird.promisifyAll(redis.Multi.prototype);
 
-const caches = {};
-
+const caches = Object.create(null);
+/* eslint-disable no-return-assign */
 module.exports = {
-  conn: (key, connection) => {
-    if (caches[key]) return caches[key];
-    caches[key] = redis.createClient(connection);
-    return caches[key];
-  },
+  conn: (key, connection) => (
+    key in caches ? caches[key] : (caches[key] = redis.createClient(connection))
+  ),
   get: async (conn, key, ttl) => {
     const tran = conn().multi();
     tran.get(key);
@@ -21,8 +21,8 @@ module.exports = {
       tran.expire(key, ttl);
     }
 
-    const res = await tran.execAsync();
-    return res[0] ? driver.payload.parse(res[0]) : null;
+    const [res] = await tran.execAsync();
+    return res ? driver.payload.parse(res) : null;
   },
   set: async (conn, key, val, ttl) => {
     const tran = conn().multi();
@@ -32,8 +32,8 @@ module.exports = {
       tran.expire(key, ttl);
     }
 
-    const res = await tran.execAsync();
-    return res[0] === 'OK';
+    const [res] = await tran.execAsync();
+    return res === 'OK';
   },
   del: async (conn, key) => {
     const res = await conn().del(key);
@@ -43,15 +43,15 @@ module.exports = {
     const tran = conn().multi();
     tran.expire(key, ttl);
 
-    const res = await tran.execAsync();
-    return res[0] === 1;
+    const [res] = await tran.execAsync();
+    return res === 1;
   },
   ttl: async (conn, key) => {
     const tran = conn().multi();
     tran.ttl(key);
 
-    const res = await tran.execAsync();
-    return res[0];
+    const [res] = await tran.execAsync();
+    return res;
   },
   close: (conn) => {
     conn().end(true);

--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const exportCacheMethods = ['get', 'set', 'del', 'expire', 'ttl', 'close'];
 const cachers = {};
 
@@ -65,7 +67,7 @@ Cache.init = (key, dsn) => {
         throw Error(`Not Implemented, ${method}`);
       }
 
-      return cacheDriver[method].apply(cacheDriver[method], [conn].concat(args));
+      return cacheDriver[method](conn, ...args);
     };
   });
 

--- a/lib/controller/index.js
+++ b/lib/controller/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const pagination = require('./library/pagination');
 
 module.exports = {

--- a/lib/controller/library/cookie.js
+++ b/lib/controller/library/cookie.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const signature = require('cookie-signature');
 
 module.exports = config => ({

--- a/lib/controller/library/pagination.js
+++ b/lib/controller/library/pagination.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const qs = require('querystring');
 
 const paginator = {

--- a/lib/controller/library/session.js
+++ b/lib/controller/library/session.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { randomBytes } = require('crypto');
 const signature = require('cookie-signature');
 const cacheLib = require('../../cache');

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const nonArrowFnRegex = /^\s*(?:class\s|(?:async)?(?:\s+function[\s*(]|(?:^|[*\s])\s*(?:['"0-9]|(?!\s|async[\s*()])[^=>()]+\s*\()))/; // needs to account for async * \u01FA() {} or get prop(){}
 
 /* NOTE: detecting for arrow functions is difficult to do with regular expressions

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const loader = require('./loader');
 
 module.exports = (config) => {

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const dpJobError = require('./misc/dp_job_error');
 
 const getExitFunc = (exitCode) => {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-disable no-underscore-dangle */
 const fs = require('fs');
 const path = require('path');

--- a/lib/misc/dp_error.js
+++ b/lib/misc/dp_error.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const DPError = function DPError(msg, req) {
   this.name = this.constructor.name;
 

--- a/lib/misc/dp_job_error.js
+++ b/lib/misc/dp_job_error.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const DPJobError = function DPJobError(err) {
   this.name = this.constructor.name;
 

--- a/lib/model/engine.js
+++ b/lib/model/engine.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Promise = require('bluebird');
 const knexQb = require('knex/lib/query/builder');
 const knexRaw = require('knex/lib/raw');

--- a/lib/model/index.js
+++ b/lib/model/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const engine = require('./engine');
 
 module.exports = (config) => {

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const createHttpError = require('http-errors');
 const bodyParser = require('body-parser');
 const ini = require('ini');

--- a/lib/static/js/dp.helper.js
+++ b/lib/static/js/dp.helper.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-disable */
 
 if (!dp) var dp = {};

--- a/lib/static/js/dp.js
+++ b/lib/static/js/dp.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-disable */
 
 var dp = {

--- a/lib/static/js/dp.test.js
+++ b/lib/static/js/dp.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-disable */
 
 if (!dp) var dp = {};

--- a/lib/static/js/dp.ui.js
+++ b/lib/static/js/dp.ui.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-disable */
 
 if (!dp) var dp = {};

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* global describe, before, after */
 /* eslint-disable no-underscore-dangle */
 
@@ -54,9 +56,7 @@ module.exports = {
 
           const cachers = global.global.__dpCachers__;
           if (cachers) {
-            Object.keys(cachers).forEach((e) => {
-              cachers[e].close();
-            });
+            Object.values(cachers).forEach(c => c.close());
           }
 
           modelEngine.destroyed = true;

--- a/lib/view/engine.js
+++ b/lib/view/engine.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { join, dirname } = require('path');
 const fs = require('fs');
 const promisedHandlebars = require('promised-handlebars');

--- a/lib/view/helpers/nl2br.js
+++ b/lib/view/helpers/nl2br.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function nl2br(hbs) {
   return function nl2brInner(str, options) {
     str = hbs.escapeExpression(str); // eslint-disable-line no-param-reassign

--- a/lib/view/helpers/pagingIdx.js
+++ b/lib/view/helpers/pagingIdx.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = (pager, index, rev) => {
   const reverse = rev === true;
   const count = pager && pager[0] ? pager[0] : 0;

--- a/lib/view/helpers/pagingItems.js
+++ b/lib/view/helpers/pagingItems.js
@@ -1,1 +1,3 @@
+'use strict';
+
 module.exports = pager => (pager && pager.length >= 2 ? pager[1] : null);

--- a/lib/view/index.js
+++ b/lib/view/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const engine = require('./engine');
 

--- a/lib/view/minifier.js
+++ b/lib/view/minifier.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { minify } = require('html-minifier');
 
 const options = {

--- a/test/example/app.js
+++ b/test/example/app.js
@@ -1,3 +1,5 @@
+'use strict';
+
 global.stage = 'local';
 
 if (process.env.APPVEYOR) {

--- a/test/example/config/cache/index.js
+++ b/test/example/config/cache/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const local = require('./local');
 const localOpt = require('./local.opt');
 const testAppveyor = require('./test.appveyor');

--- a/test/example/config/cache/local.js
+++ b/test/example/config/cache/local.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   client: 'redis',
   connection: {

--- a/test/example/config/cache/local.opt.js
+++ b/test/example/config/cache/local.opt.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   client: 'redis',
   connection: {

--- a/test/example/config/cache/mem.js
+++ b/test/example/config/cache/mem.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   client: 'memory',
 };

--- a/test/example/config/cache/nine.js
+++ b/test/example/config/cache/nine.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   client: 'redis',
   connection: {

--- a/test/example/config/cache/test.appveyor.js
+++ b/test/example/config/cache/test.appveyor.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   client: 'redis',
   connection: {

--- a/test/example/config/cache/test.travis.js
+++ b/test/example/config/cache/test.travis.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   client: 'redis',
   connection: {

--- a/test/example/config/db.js
+++ b/test/example/config/db.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const local = require('./db.local');
 const localOpt = require('./db.local.opt');
 const testAppveyor = require('./db.test.appveyor');

--- a/test/example/config/db.local.js
+++ b/test/example/config/db.local.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   key: 'local',
   client: 'mysql',

--- a/test/example/config/db.local.opt.js
+++ b/test/example/config/db.local.opt.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   key: 'localOpt',
   client: 'mysql',

--- a/test/example/config/db.test.appveyor.js
+++ b/test/example/config/db.test.appveyor.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   key: 'testAppveyor',
   client: 'mysql',

--- a/test/example/config/db.test.appveyor.opt.js
+++ b/test/example/config/db.test.appveyor.opt.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   key: 'testAppveyorOpt',
   client: 'mysql',

--- a/test/example/config/db.test.travis.js
+++ b/test/example/config/db.test.travis.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   key: 'testTravis',
   client: 'mysql',

--- a/test/example/config/db.test.travis.opt.js
+++ b/test/example/config/db.test.travis.opt.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   key: 'testTravisOpt',
   client: 'mysql',

--- a/test/example/controller/_.js
+++ b/test/example/controller/_.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = (req, res, next) => {
   res.async((dp) => { // eslint-disable-line no-unused-vars
     next();

--- a/test/example/controller/cache/index.js
+++ b/test/example/controller/cache/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/controller/controller/config/child.js
+++ b/test/example/controller/controller/config/child.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => '/controller/config/this/prefix/will/be/added/to/all/child/paths/child',
 };

--- a/test/example/controller/controller/config/index.js
+++ b/test/example/controller/controller/config/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => '/controller/config/this/prefix/will/be/added/to/all/child/paths',
 };

--- a/test/example/controller/controller/config/propagation/index.js
+++ b/test/example/controller/controller/config/propagation/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get() {
     return 'propagation';

--- a/test/example/controller/controller/config/propagation/propagatable/bubbling/child/index.js
+++ b/test/example/controller/controller/config/propagation/propagatable/bubbling/child/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get() {
     return 'child';

--- a/test/example/controller/controller/config/propagation/propagatable/bubbling/index.js
+++ b/test/example/controller/controller/config/propagation/propagatable/bubbling/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get() {
     return 'bubbling';

--- a/test/example/controller/controller/config/propagation/propagatable/index.js
+++ b/test/example/controller/controller/config/propagation/propagatable/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get() {
     return 'propagatable';

--- a/test/example/controller/controller/config/sub/child.js
+++ b/test/example/controller/controller/config/sub/child.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => '/controller/config/this/prefix/will/be/added/to/all/child/paths/sub/child',
 };

--- a/test/example/controller/controller/config/to_root/index.js
+++ b/test/example/controller/controller/config/to_root/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => '/this/prefix/will/be/added/to/all/child/paths/as/root',
 };

--- a/test/example/controller/controller/config/to_root/sub/child.js
+++ b/test/example/controller/controller/config/to_root/sub/child.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => '/this/prefix/will/be/added/to/all/child/paths/as/root/sub/child',
 };

--- a/test/example/controller/controller/config/to_root/sub/index.js
+++ b/test/example/controller/controller/config/to_root/sub/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => '/this/prefix/will/be/added/to/all/child/paths/as/root/sub',
 };

--- a/test/example/controller/controller/config/with_regex/index.js
+++ b/test/example/controller/controller/config/with_regex/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get() {
     return this.params('id', true);

--- a/test/example/controller/controller/config/with_replace_all/cond.js
+++ b/test/example/controller/controller/config/with_replace_all/cond.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   _: '/cond/:val1(\\d+)',
   get: controller => `/globally_replaced_to_root_all/cond/${controller.params('val1', true)}`,

--- a/test/example/controller/controller/config/with_replace_all/index.js
+++ b/test/example/controller/controller/config/with_replace_all/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   _: '/:val1',
   get: controller => `/globally_replaced_to_root_all/${controller.params('val1', true)}`,

--- a/test/example/controller/controller/config/with_replace_method/index.js
+++ b/test/example/controller/controller/config/with_replace_method/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get_: '/:val1',
   get: controller => `/globally_replaced_to_root/${controller.params('val1', true)}`,

--- a/test/example/controller/controller/config/with_replace_method/prefix.js
+++ b/test/example/controller/controller/config/with_replace_method/prefix.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   _get: '/with_prefix/:val1',
   get: controller => `/globally_replaced_to_root/with_prefix/${controller.params('val1', true)}`,

--- a/test/example/controller/controller/finisher/by_code/denied.js
+++ b/test/example/controller/controller/finisher/by_code/denied.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finisher.denied('DENIED');

--- a/test/example/controller/controller/finisher/by_code/error.js
+++ b/test/example/controller/controller/finisher/by_code/error.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finisher.error('ERROR');

--- a/test/example/controller/controller/finisher/by_code/invalid.js
+++ b/test/example/controller/controller/finisher/by_code/invalid.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finisher.invalid('INVALID');

--- a/test/example/controller/controller/finisher/by_code/notfound.js
+++ b/test/example/controller/controller/finisher/by_code/notfound.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finisher.notfound('NOTFOUND');

--- a/test/example/controller/controller/finisher/by_code/unauthorized.js
+++ b/test/example/controller/controller/finisher/by_code/unauthorized.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finisher.unauthorized('UNAUTHORIZED');

--- a/test/example/controller/controller/finisher/redirect/index.js
+++ b/test/example/controller/controller/finisher/redirect/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.redirect('/');

--- a/test/example/controller/controller/finisher/redirect/with_code.js
+++ b/test/example/controller/controller/finisher/redirect/with_code.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.redirect('/', 301);

--- a/test/example/controller/controller/finisher/redirect/with_code2.js
+++ b/test/example/controller/controller/finisher/redirect/with_code2.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.redirect(301, '/');

--- a/test/example/controller/controller/req/uri.js
+++ b/test/example/controller/controller/req/uri.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish(controller.req.uri());

--- a/test/example/controller/controller/req/url.js
+++ b/test/example/controller/controller/req/url.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish(controller.req.url());

--- a/test/example/controller/error/404.js
+++ b/test/example/controller/error/404.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finisher.notfound('NOTFOUND');

--- a/test/example/controller/error/500_code.js
+++ b/test/example/controller/error/500_code.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finisher.error('ERROR');

--- a/test/example/controller/error/500_handler.js
+++ b/test/example/controller/error/500_handler.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => {
     throw Error('ERROR');

--- a/test/example/controller/error/handler/throw_from_model.js
+++ b/test/example/controller/error/handler/throw_from_model.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: async controller => controller.model.test.error.throwFromMethod(),
 };

--- a/test/example/controller/error/handler/throw_from_query.js
+++ b/test/example/controller/error/handler/throw_from_query.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: async (controller) => {
     const res = await controller.model.test.error.throwFromQuery();

--- a/test/example/controller/helper/delegate.js
+++ b/test/example/controller/helper/delegate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/controller/helper/simple.js
+++ b/test/example/controller/helper/simple.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/controller/index.js
+++ b/test/example/controller/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish('dp-node');

--- a/test/example/controller/middleware/file/_.js
+++ b/test/example/controller/middleware/file/_.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = (req, res, next) => { // eslint-disable-line no-unused-vars
   res.async((dp) => { // eslint-disable-line no-unused-vars
     res.status(200).send('file/middleware');

--- a/test/example/controller/middleware/file/child/grandchild/_.js
+++ b/test/example/controller/middleware/file/child/grandchild/_.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = (req, res, next) => { // eslint-disable-line no-unused-vars
   res.async((dp) => { // eslint-disable-line no-unused-vars
     res.status(200).send('file/child/grandchild/middleware');

--- a/test/example/controller/middleware/file/child/grandchild/index.js
+++ b/test/example/controller/middleware/file/child/grandchild/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish('file/child/grandchild/get');

--- a/test/example/controller/middleware/file/child/grandchild2.js
+++ b/test/example/controller/middleware/file/child/grandchild2.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish('file/child/grandchild2');

--- a/test/example/controller/middleware/file/child/index.js
+++ b/test/example/controller/middleware/file/child/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish('file/child/get');

--- a/test/example/controller/middleware/file/child2.js
+++ b/test/example/controller/middleware/file/child2.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish('file/child2/get');

--- a/test/example/controller/middleware/file/child3.js
+++ b/test/example/controller/middleware/file/child3.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   __: (req, res, next) => { // eslint-disable-line no-unused-vars
     res.status(200).send('file/child3/middleware');

--- a/test/example/controller/middleware/file/end/_.js
+++ b/test/example/controller/middleware/file/end/_.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = (req, res, next) => {
   res.async((dp) => { // eslint-disable-line no-unused-vars
     next();

--- a/test/example/controller/middleware/file/end/__.js
+++ b/test/example/controller/middleware/file/end/__.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = (req, res, next) => {
   res.async((dp) => {
     dp.controller.finish(`middleware-for-end-and-${res.buffer.body}`);

--- a/test/example/controller/middleware/file/end/ignore.js
+++ b/test/example/controller/middleware/file/end/ignore.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish('IGNORED');

--- a/test/example/controller/middleware/file/end/index.js
+++ b/test/example/controller/middleware/file/end/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => 'returned-value',
 };

--- a/test/example/controller/middleware/file/error/_.js
+++ b/test/example/controller/middleware/file/error/_.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const CustomError = function CustomError(message) {
   Error.captureStackTrace(this, this.constructor);
 

--- a/test/example/controller/middleware/file/error/index.js
+++ b/test/example/controller/middleware/file/error/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => {
     throw Error('/middleware/file/error');

--- a/test/example/controller/middleware/file/error2/_.js
+++ b/test/example/controller/middleware/file/error2/_.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const CustomError = function CustomError(message) {
   Error.captureStackTrace(this, this.constructor);
 

--- a/test/example/controller/middleware/file/error2/index.js
+++ b/test/example/controller/middleware/file/error2/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => {
     throw Error('/middleware/file/error');

--- a/test/example/controller/middleware/file/index.js
+++ b/test/example/controller/middleware/file/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish('file/get');

--- a/test/example/controller/middleware/file/not_async/_.js
+++ b/test/example/controller/middleware/file/not_async/_.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = (req, res, next) => {
   res.testBegin = 'begin';
 

--- a/test/example/controller/middleware/file/not_async/__.js
+++ b/test/example/controller/middleware/file/not_async/__.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = (req, res, next) => { // eslint-disable-line no-unused-vars
   res.status(200).send(`${res.testBegin}-${res.buffer.body}-${res.testController}`);
 };

--- a/test/example/controller/middleware/file/not_async/index.js
+++ b/test/example/controller/middleware/file/not_async/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.raw.res.testController = 'controller'; // eslint-disable-line no-param-reassign

--- a/test/example/controller/middleware/for-all.js
+++ b/test/example/controller/middleware/for-all.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   middleware: (req, res, next) => {
     const token = req.get('DP-NODE-TOKEN');

--- a/test/example/controller/middleware/index.js
+++ b/test/example/controller/middleware/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   getMiddleware: (req, res, next) => {
     const token = req.get('DP-NODE-TOKEN');

--- a/test/example/controller/middleware/multiple.js
+++ b/test/example/controller/middleware/multiple.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   getMiddlewares: [
     (req, res, next) => {

--- a/test/example/controller/middleware/pre-post/.err.js
+++ b/test/example/controller/middleware/pre-post/.err.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = async (controller, error) => {
   return `${error.message}`;
 };

--- a/test/example/controller/middleware/pre-post/.post.js
+++ b/test/example/controller/middleware/pre-post/.post.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller, data) => {
     return `${data}-post`;

--- a/test/example/controller/middleware/pre-post/.pre.js
+++ b/test/example/controller/middleware/pre-post/.pre.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   async get() {
     return this.model.data.foo.pre;

--- a/test/example/controller/middleware/pre-post/child/sub.js
+++ b/test/example/controller/middleware/pre-post/child/sub.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller, data) => `${data}-sub`,
 };

--- a/test/example/controller/middleware/pre-post/error.js
+++ b/test/example/controller/middleware/pre-post/error.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: () => {
     throw Error('An intended exception.');

--- a/test/example/controller/middleware/pre-post/for-all/.post.js
+++ b/test/example/controller/middleware/pre-post/for-all/.post.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   all: (controller, data) => {
     return `${data}-f-post`;

--- a/test/example/controller/middleware/pre-post/for-all/.pre.js
+++ b/test/example/controller/middleware/pre-post/for-all/.pre.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   all: (controller) => {
     return 'f-pre';

--- a/test/example/controller/middleware/pre-post/for-all/index.js
+++ b/test/example/controller/middleware/pre-post/for-all/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller, data) => `${data}-for-all`,
 };

--- a/test/example/controller/middleware/pre-post/index.js
+++ b/test/example/controller/middleware/pre-post/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   async get(data) {
     return `${data}-body`;

--- a/test/example/controller/middleware/pre-post/replace/.err.js
+++ b/test/example/controller/middleware/pre-post/replace/.err.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = async (controller, error) => {
   controller.finishWithCode(401, 'Intended 401 Error')
 };

--- a/test/example/controller/middleware/pre-post/replace/.post.js
+++ b/test/example/controller/middleware/pre-post/replace/.post.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller, data) => {
     return `${data}-r-post`;

--- a/test/example/controller/middleware/pre-post/replace/.pre.js
+++ b/test/example/controller/middleware/pre-post/replace/.pre.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     return 'r-pre';

--- a/test/example/controller/middleware/pre-post/replace/path.js
+++ b/test/example/controller/middleware/pre-post/replace/path.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller, data) => `${data}-r-path`,
 };

--- a/test/example/controller/model/loader.js
+++ b/test/example/controller/model/loader.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/controller/model/mysql/group.js
+++ b/test/example/controller/model/mysql/group.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   async get() {
     await this.model.test.group.test();

--- a/test/example/controller/model/mysql/simple.js
+++ b/test/example/controller/model/mysql/simple.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/controller/model/mysql/tran.js
+++ b/test/example/controller/model/mysql/tran.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/controller/model/prop.js
+++ b/test/example/controller/model/prop.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/controller/routing/index.js
+++ b/test/example/controller/routing/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish('GET /routing');

--- a/test/example/controller/routing/replace/alias/all.js
+++ b/test/example/controller/routing/replace/alias/all.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   _: '/it-is-a-replaced-path-for-all-methods-alias',
   get: (controller) => {

--- a/test/example/controller/routing/replace/alias/index.js
+++ b/test/example/controller/routing/replace/alias/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   _get: '/it-is-a-replaced-path-alias', // _get is alias for getPath
   get: (controller) => {

--- a/test/example/controller/routing/replace/all.js
+++ b/test/example/controller/routing/replace/all.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   path: '/it-is-a-replaced-path-for-all-methods',
   get: (controller) => {

--- a/test/example/controller/routing/replace/index.js
+++ b/test/example/controller/routing/replace/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   getPath: '/it-is-a-replaced-path',
   get: (controller) => {

--- a/test/example/controller/routing/replace/with_params/alias.js
+++ b/test/example/controller/routing/replace/with_params/alias.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   _get: '/replaced-alias-path-with-suffix',
   get_: '/:id(\\d+)?',

--- a/test/example/controller/routing/replace/with_params/index.js
+++ b/test/example/controller/routing/replace/with_params/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   getPath: '/replaced-path-with-suffix',
   getSuffix: '/:id(\\d+)?',

--- a/test/example/controller/routing/sub/path.js
+++ b/test/example/controller/routing/sub/path.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish('/routing/sub/path');

--- a/test/example/controller/routing/with_params/23.js
+++ b/test/example/controller/routing/with_params/23.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: (controller) => {
     controller.finish('/routing/with_params/23');

--- a/test/example/controller/routing/with_params/alias.js
+++ b/test/example/controller/routing/with_params/alias.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get_: '/:id(\\d+)?',
   get: (controller) => {

--- a/test/example/controller/routing/with_params/index.js
+++ b/test/example/controller/routing/with_params/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   getSuffix: '/:id(\\d+)?',
   get: (controller) => {

--- a/test/example/controller/session/index.js
+++ b/test/example/controller/session/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/controller/view/includes.js
+++ b/test/example/controller/view/includes.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: async (controller) => {
     await controller.render('view/includes.html');

--- a/test/example/controller/view/includes_nosuffix.js
+++ b/test/example/controller/view/includes_nosuffix.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: async (controller) => {
     await controller.render('view/includes_nosuffix.html');

--- a/test/example/controller/view/simple_render.js
+++ b/test/example/controller/view/simple_render.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   get: async (controller) => {
     await controller.render('view/simple_render.html');

--- a/test/example/dummy.js
+++ b/test/example/dummy.js
@@ -1,3 +1,5 @@
+'use strict';
+
 require('express');
 require('cookie');
 require('cookie-parser');

--- a/test/example/error.js
+++ b/test/example/error.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = async (controller, error, statusCode) => {

--- a/test/example/helper.js
+++ b/test/example/helper.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
 
 };

--- a/test/example/helper/bar.js
+++ b/test/example/helper/bar.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   async barAsync() {
     return new Promise((resolve) => {

--- a/test/example/helper/cache.js
+++ b/test/example/helper/cache.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/helper/foo.js
+++ b/test/example/helper/foo.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   bar() {
     return 'bar';

--- a/test/example/job/async_job.js
+++ b/test/example/job/async_job.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 global.mode = 'job';

--- a/test/example/job/render_view.js
+++ b/test/example/job/render_view.js
@@ -1,3 +1,5 @@
+'use strict';
+
 global.mode = 'job';
 global.DP_NODE_JOB_UNCAUGHT_FATAL_EXCEPTION_CODE = 0;
 

--- a/test/example/job/test.js
+++ b/test/example/job/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 global.mode = 'job';
 require('../app')(() => {
   console.log('done'); // eslint-disable-line no-console

--- a/test/example/job/test_error.js
+++ b/test/example/job/test_error.js
@@ -1,3 +1,5 @@
+'use strict';
+
 global.mode = 'job';
 global.DP_NODE_JOB_UNCAUGHT_FATAL_EXCEPTION_CODE = 0;
 

--- a/test/example/model/data/foo.js
+++ b/test/example/model/data/foo.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   bar: 'bar',
   baz: () => 'baz',

--- a/test/example/model/loader/bar/bar_camel/foo.js
+++ b/test/example/model/loader/bar/bar_camel/foo.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test: () => 'model.loader.bar.barCamel.foo.test',
 };

--- a/test/example/model/loader/bar/bar_camel/without_index.js
+++ b/test/example/model/loader/bar/bar_camel/without_index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test: () => 'model.loader.bar.barCamel.withoutIndex.test',
 };

--- a/test/example/model/loader/bar/bazCamel/foo.js
+++ b/test/example/model/loader/bar/bazCamel/foo.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test: () => 'model.loader.bar.bazCamel.foo.test',
 };

--- a/test/example/model/loader/bar/bazCamel/without_index.js
+++ b/test/example/model/loader/bar/bazCamel/without_index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test: () => 'model.loader.bar.bazCamel.withoutIndex.test',
 };

--- a/test/example/model/loader/foo/foo_camel/foo.js
+++ b/test/example/model/loader/foo/foo_camel/foo.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test: () => 'model.loader.foo.fooCamel.foo.test',
 };

--- a/test/example/model/loader/foo/foo_camel/index.js
+++ b/test/example/model/loader/foo/foo_camel/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test: () => 'model.loader.foo.fooCamel.test',
 };

--- a/test/example/model/loader/foo/foo_camel/with_index.js
+++ b/test/example/model/loader/foo/foo_camel/with_index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test: () => 'model.loader.foo.fooCamel.withIndex.test',
 };

--- a/test/example/model/loader/foo/fozCamel/foo.js
+++ b/test/example/model/loader/foo/fozCamel/foo.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test: () => 'model.loader.foo.fozCamel.foo.test',
 };

--- a/test/example/model/loader/foo/fozCamel/index.js
+++ b/test/example/model/loader/foo/fozCamel/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test: () => 'model.loader.foz.fooCamel.test',
 };

--- a/test/example/model/loader/foo/fozCamel/with_index.js
+++ b/test/example/model/loader/foo/fozCamel/with_index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test: () => 'model.loader.foo.fozCamel.withIndex.test',
 };

--- a/test/example/model/middleware/token.js
+++ b/test/example/model/middleware/token.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   validate(token) {
     return token && String(token).length === 10;

--- a/test/example/model/test/cache.js
+++ b/test/example/model/test/cache.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/model/test/error/index.js
+++ b/test/example/model/test/error/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   throwFromMethod: () => {
     throw Error('This is an intended exception.');

--- a/test/example/model/test/group.js
+++ b/test/example/model/test/group.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/model/test/index.js
+++ b/test/example/model/test/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   underscoreCalc(a, b) {
     return this._.underscore.calc(this._.uscore.baz.ret(a), b);

--- a/test/example/model/test/knex.js
+++ b/test/example/model/test/knex.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/model/test/options.js
+++ b/test/example/model/test/options.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 const Fn = function Fn(val) {

--- a/test/example/model/test/tran.js
+++ b/test/example/model/test/tran.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 
 module.exports = {

--- a/test/example/model/test/underscore.js
+++ b/test/example/model/test/underscore.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   calc(a, b) {
     return a + b;

--- a/test/example/model/test/uscore/bar.js
+++ b/test/example/model/test/uscore/bar.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   koo: 'koo',
 };

--- a/test/example/model/test/uscore/baz/foz.js
+++ b/test/example/model/test/uscore/baz/foz.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   zoo: 'zoo',
 };

--- a/test/example/model/test/uscore/baz/index.js
+++ b/test/example/model/test/uscore/baz/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   ret(a) {
     return a;

--- a/test/example/model/test/uscore/foo/far.js
+++ b/test/example/model/test/uscore/foo/far.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   fao: 'fao',
 };

--- a/test/example/model/test/uscore/foo/index.js
+++ b/test/example/model/test/uscore/foo/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   fao() {
     return this._.far.fao;

--- a/test/example/model/test/uscore/one/in_one/index.js
+++ b/test/example/model/test/uscore/one/in_one/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   two() {
     return this.__.__.two.one.three; // eslint-disable-line no-underscore-dangle

--- a/test/example/model/test/uscore/qux/index.js
+++ b/test/example/model/test/uscore/qux/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   fao() {
     return this.__.foo.fao(); // eslint-disable-line no-underscore-dangle

--- a/test/example/model/test/uscore/qux/quux.js
+++ b/test/example/model/test/uscore/qux/quux.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   fred: 'fred',
   mos: 'mos',

--- a/test/example/model/test/uscore/two/one.js
+++ b/test/example/model/test/uscore/two/one.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   three: 'three',
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 const CliTest = require('command-line-test');
 


### PR DESCRIPTION
 * (.eslintrc.js) Airbnb's ESLint config assumes ES6 modules syntax, but
   this project does not adopt it and uses Node.js/CommonJS module
   system instead. Switched to "script" mode for correctness.
 * "use strict"; because performance & safety
 * Memory cache functions are now stable w.r.t. current time, meaning
   an entry not expired when queried will remain in that state until
   the next tick.
 * Use Object.create(null) where appropriate, to avoid key collisions
   with Object.prototype (e.g. propertyIsEnumerable, hasOwnProperty,
   toString, valueOf, ...)