### PR TITLE
ESLint, undo stable t, less mem footprint, IE9 support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,4 +6,36 @@ module.exports = {
   "env": {
     "jest": true
   },
+  "rules": {
+    "global-require": "off",
+    "import/no-dynamic-require": "off",
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline",
+      "functions": "never"
+    }],
+    "no-console": "off",
+    "new-cap": ["error", {
+      "newIsCap": true,
+      "newIsCapExceptions": [
+        "dpError",
+        "dpJobError"
+      ],
+      "capIsNew": false,
+      "capIsNewExceptions": [
+        "Immutable.Map",
+        "Immutable.Set",
+        "Immutable.List"
+      ]
+    }],
+    "no-underscore-dangle": "off",
+    "no-unused-vars": ["error", {
+      "vars": "all",
+      "args": "after-used",
+      "ignoreRestSiblings": true,
+      "argsIgnorePattern": "^_"
+    }]
+  }
 };

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ $ npm install dp-node
 
 ## Features
 
-  * Focus on faster development.
-  * Async/Await ready.
+  * Rapid prototyping
+  * async / await ready
 
 ## Quick Start
 

--- a/lib/cache/driver/index.js
+++ b/lib/cache/driver/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* eslint-disable no-unused-vars */
+/* eslint no-unused-vars: ["error", { "vars": "all", "args": "none" }] */
 
 module.exports = {
   conn: (connection) => {
@@ -29,7 +29,9 @@ module.exports = {
       try {
         const parsed = JSON.parse(str);
         return parsed.p;
-      } catch (_) {} // eslint-disable-line no-empty
+      } catch (_) {
+        // Ignore invalid JSON
+      }
 
       return null;
     },

--- a/lib/cache/driver/memory.js
+++ b/lib/cache/driver/memory.js
@@ -1,31 +1,21 @@
 'use strict';
 
-const { nextTick } = process;
-let lastNow = null;
-function now() {
-  if (lastNow == null) {
-    const ts = Date.now();
-    nextTick(() => { lastNow = null; });
-    lastNow = ts;
-  }
-  return lastNow;
-}
 function Cacher() {
   let values = Object.create(null);
   this.get = (key) => {
     const val = values[key];
     if (!val) return undefined;
-    return val.exp == null || val.exp > now() ? val.val : null;
+    return val.exp == null || val.exp > Date.now() ? val.val : null;
   };
   this.set = (key, val, ttl) => {
-    const exp = ttl ? now() + ttl * 1e3 : null;
+    const exp = ttl ? Date.now() + ttl * 1e3 : null;
     values[key] = { val, exp };
     return true;
   };
   this.del = key => delete values[key];
   this.expire = (key, ttl) => {
     const val = values[key];
-    const ts = now();
+    const ts = Date.now();
     if (!val || ts >= val.exp) return null;
 
     val.exp = ts + (ttl * 1e3);
@@ -33,7 +23,7 @@ function Cacher() {
   };
   this.ttl = (key) => {
     const val = values[key];
-    const ts = now();
+    const ts = Date.now();
     return val && ts < val.exp ? (val.exp - ts) * 1e-3 : -1;
   };
   this.close = () => {

--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -3,26 +3,22 @@
 const exportCacheMethods = ['get', 'set', 'del', 'expire', 'ttl', 'close'];
 const cachers = {};
 
-const Cache = function Cache(config) {
+function Cache(config) {
   // Assign engine when test mode enabled.
   if (global.isTest) {
-    global.__dpCachers__ = cachers; // eslint-disable-line no-underscore-dangle
+    global.__dpCachers__ = cachers;
   }
 
-  const Cacher = function Cacher(key) {
+  function Cacher(key) {
     const dsn = (config.cfg.cacheDsn || {})[key];
-
-    if (!dsn) {
-      throw new Error(`The speified 'dsn(${key})' is not found.`);
-    }
-
+    if (!dsn) throw new Error(`The speified 'dsn(${key})' is not found.`);
     return Cache.init(key, dsn);
-  };
+  }
 
-  const defDsnKey = Object.keys(config.cfg.cacheDsn || {}).find(e => e);
-  const defDsn = config.cfg.cacheDsn.default || (defDsnKey ? config.cfg.cacheDsn[defDsnKey] : null);
+  const defDsnKey = Object.keys(config.cfg.cacheDsn || {}).find(Boolean);
+  const defDsn = config.cfg.cacheDsn.default || (defDsnKey && config.cfg.cacheDsn[defDsnKey]);
   const defCacherKey = `default-${Date.now()}`;
-  const defCacher = defDsn ? Cache.init(defCacherKey, defDsn) : null;
+  const defCacher = defDsn && Cache.init(defCacherKey, defDsn);
 
   exportCacheMethods.forEach((method) => {
     Cacher[method] = (...args) => {
@@ -32,44 +28,50 @@ const Cache = function Cache(config) {
   });
 
   return Cacher;
+}
+
+const knownDrivers = {
+  memory: 'memory',
+  redis: 'redis',
 };
+const hasOwn = Object.prototype.hasOwnProperty;
 
 Cache.init = (key, dsn) => {
-  if (cachers[key]) return cachers[key];
+  const existing = cachers[key];
+  if (existing) return existing;
 
-  let cacheDriver;
   const driver = dsn.driver || dsn.client;
 
-  if (driver === 'memory') {
-    cacheDriver = require('./driver/memory'); // eslint-disable-line global-require
-  } else if (driver === 'redis') {
-    cacheDriver = require('./driver/redis'); // eslint-disable-line global-require
-  } else {
-    cacheDriver = require('./driver'); // eslint-disable-line global-require
+  let driverModule = './driver';
+  if (hasOwn.call(knownDrivers, driver)) {
+    driverModule = `${driverModule}/${knownDrivers[driver]}`;
   }
+  const cacheDriver = require(driverModule);
 
   if (!cacheDriver.conn) {
     throw Error('Not Implemented, conn.');
   }
 
-  const proxy = {};
   let connLazy;
   const conn = () => {
-    if (connLazy) return connLazy;
-    connLazy = cacheDriver.conn(key, dsn.connection);
+    if (!connLazy) connLazy = cacheDriver.conn(key, dsn.connection);
     return connLazy;
   };
 
+  const proxy = {};
   // Available cache functions. get, set, del, ...
-  exportCacheMethods.forEach((method) => {
-    proxy[method] = (...args) => {
+  exportCacheMethods.forEach(method => Object.defineProperty(proxy, method, {
+    value(...args) {
       if (!cacheDriver[method]) {
         throw Error(`Not Implemented, ${method}`);
       }
 
       return cacheDriver[method](conn, ...args);
-    };
-  });
+    },
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  }));
 
   cachers[key] = proxy;
   return proxy;

--- a/lib/controller/index.js
+++ b/lib/controller/index.js
@@ -2,128 +2,170 @@
 
 const pagination = require('./library/pagination');
 
+const symPrivate = Symbol('dp-node.private');
+class Finisher {
+  constructor(controller) {
+    this[symPrivate] = controller;
+  }
+
+  notfound(body) {
+    return this[symPrivate].finishWithCode(404, body);
+  }
+
+  invalid(body) {
+    return this[symPrivate].finishWithCode(400, body);
+  }
+
+  unauthorized(body) {
+    return this[symPrivate].finishWithCode(401, body);
+  }
+
+  denied(body) {
+    return this[symPrivate].finishWithCode(403, body);
+  }
+
+  error(body) {
+    return this[symPrivate].finishWithCode(500, body);
+  }
+}
+
+class RequestInfo {
+  constructor(req) {
+    this[symPrivate] = req;
+  }
+
+  url() {
+    const req = this[symPrivate];
+    return `${req.protocol}://${req.get('host')}`;
+  }
+
+  uri() {
+    const req = this[symPrivate];
+    return `${req.protocol}://${req.get('host')}${req.originalUrl}`;
+  }
+}
+
+class Controller {
+  constructor(config, req, res, session, cookie) {
+    this.raw = { req, res };
+    this.req = new RequestInfo(req);
+    this.cache = config.cache;
+    this.model = config.model;
+    this.helper = config.helper;
+    this.session = {
+      id: session.id.bind(session, req, res),
+      set: session.set.bind(session, req, res),
+      get: session.get.bind(session, req, res),
+      del: session.del.bind(session, req, res),
+      ttl: session.ttl.bind(session, req, res),
+      expire: session.expire.bind(session, req, res),
+    };
+    this.cookie = {
+      get: cookie.get.bind(cookie, req, res),
+      set: cookie.set.bind(cookie, req, res),
+    };
+    this.finisher = new Finisher(this);
+    this.render = (view, params, opts) => (
+      Promise.resolve(config.view.render(view, params, opts)).then(s => this.finish(s)));
+    this.renderString = (view, params, opts) => (
+      Promise.resolve(config.view.render(view, params, opts)));
+  }
+
+  remoteIp(all) {
+    const { req } = this.raw;
+    return all ? req.ips : req.ip;
+  }
+
+  params(key, url) {
+    const { req } = this.raw;
+    if (url) {
+      return req.params ? req.params[key] : null;
+    }
+
+    if (req.method === 'GET') {
+      return req.query ? req.query[key] : null;
+    }
+    return req.body ? req.body[key] : null;
+  }
+
+  headers(key) {
+    return this.raw.req.get(key);
+  }
+
+  redirect(url, statusCode) {
+    if (typeof url === 'string' && typeof statusCode === 'number') {
+      const temp = url;
+      url = statusCode; // eslint-disable-line no-param-reassign
+      statusCode = temp; // eslint-disable-line no-param-reassign
+    }
+
+    const { res } = this.raw;
+    if (res.isDoNotUseFinishBuffer) {
+      if (statusCode) {
+        res.redirect(url, statusCode);
+      } else {
+        res.redirect(url);
+      }
+    } else {
+      res.bufferRedirect = {
+        url,
+        code: statusCode || null,
+      };
+    }
+  }
+
+  finish(body) {
+    return this.finishWithCode(200, body);
+  }
+
+  finishWithCode(code, body) {
+    if (!body) {
+      if (code === 404) {
+        body = 'Page not found.'; // eslint-disable-line no-param-reassign
+      } else if (code === 403) {
+        body = 'Forbidden.'; // eslint-disable-line no-param-reassign
+      } else if (code === 400) {
+        body = 'Invalid Request.'; // eslint-disable-line no-param-reassign
+      } else if (code >= 500 && code < 600) {
+        body = 'An error has occurred.'; // eslint-disable-line no-param-reassign
+      }
+    }
+
+    const { res } = this.raw;
+    if (res.isDoNotUseFinishBuffer) {
+      res.status(code).send(body);
+    } else {
+      res.buffer = { code, body };
+    }
+  }
+
+  pagination(options, addOptions) {
+    const { req, res } = this.raw;
+    return pagination(req, res, options, addOptions);
+  }
+}
+
 module.exports = {
   handler: {
     serverError: (controller, req, res, config, err, statusCode) => {
       res.isDoNotUseFinishBuffer = true;
 
       if (statusCode !== 404 && config.cfg.errorLogging) {
-        console.error('-------'); // eslint-disable-line no-console
-        console.error('[ERROR]'); // eslint-disable-line no-console
-        console.error('-------'); // eslint-disable-line no-console
-        console.error(err); // eslint-disable-line no-console
-        console.error('-------'); // eslint-disable-line no-console
+        console.error('-------');
+        console.error('[ERROR]');
+        console.error('-------');
+        console.error(err);
+        console.error('-------');
       }
 
-      if (typeof config.handler.error === 'function') {
-        config.handler.error(controller, err, statusCode);
+      const { handler } = config;
+      if (typeof handler.error === 'function') {
+        handler.error(controller, err, statusCode);
       } else {
         res.status(statusCode || 500).send('An error has occurred.');
       }
     },
   },
-  delegate: (config, req, res, session, cookie) => {
-    const controller = {
-      raw: {
-        req,
-        res,
-      },
-      req: {
-        url: () => `${req.protocol}://${req.get('host')}`,
-        uri: () => `${req.protocol}://${req.get('host')}${req.originalUrl}`,
-      },
-      remoteIp: all => (all ? req.ips : req.ip),
-      cache: config.cache,
-      model: config.model,
-      helper: config.helper,
-      session: {
-        id: renewOrSet => session.id(req, res, renewOrSet),
-        set: (key, val, ttl) => session.set(req, res, key, val, ttl),
-        get: (key, ttl) => session.get(req, res, key, ttl),
-        del: key => session.del(req, res, key),
-        ttl: key => session.ttl(req, res, key),
-        expire: (key, ttl) => session.expire(req, res, key, ttl),
-      },
-      cookie: {
-        get: key => cookie.get(req, res, key),
-        set: (key, val, opts) => cookie.set(req, res, key, val, opts),
-      },
-      params: (key, url) => {
-        if (url) {
-          return req.params ? req.params[key] : null;
-        }
-
-        if (req.method === 'GET') {
-          return req.query ? req.query[key] : null;
-        }
-        return req.body ? req.body[key] : null;
-      },
-      headers: key => req.get(key),
-      redirect: (url, statusCode) => {
-        if (typeof url === 'string' && typeof statusCode === 'number') {
-          const temp = url;
-          url = statusCode; // eslint-disable-line no-param-reassign
-          statusCode = temp; // eslint-disable-line no-param-reassign
-        }
-
-        if (res.isDoNotUseFinishBuffer) {
-          if (statusCode) {
-            res.redirect(url, statusCode);
-          } else {
-            res.redirect(url);
-          }
-        } else {
-          res.bufferRedirect = {
-            url,
-            code: statusCode || null,
-          };
-        }
-      },
-      finish: (body) => {
-        controller.finishWithCode(200, body);
-      },
-      finisher: {
-        notfound(body) {
-          controller.finishWithCode(404, body);
-        },
-        invalid(body) {
-          controller.finishWithCode(400, body);
-        },
-        unauthorized(body) {
-          controller.finishWithCode(401, body);
-        },
-        denied(body) {
-          controller.finishWithCode(403, body);
-        },
-        error(body) {
-          controller.finishWithCode(500, body);
-        },
-      },
-      finishWithCode: (code, body) => {
-        if (!body) {
-          if (code === 404) {
-            body = 'Page not found.'; // eslint-disable-line no-param-reassign
-          } else if (code === 403) {
-            body = 'Forbidden.'; // eslint-disable-line no-param-reassign
-          } else if (code === 400) {
-            body = 'Invalid Request.'; // eslint-disable-line no-param-reassign
-          } else if (code >= 500 && code < 600) {
-            body = 'An error has occurred.'; // eslint-disable-line no-param-reassign
-          }
-        }
-
-        if (res.isDoNotUseFinishBuffer) {
-          res.status(code).send(body);
-        } else {
-          res.buffer = { code, body };
-        }
-      },
-      render: (view, params, opts) => (
-        Promise.resolve(config.view.render(view, params, opts)).then(s => controller.finish(s))),
-      renderString: (view, params, opts) => Promise.resolve(config.view.render(view, params, opts)),
-      pagination: (options, addOptions) => pagination(req, res, options, addOptions),
-    };
-
-    return controller;
-  },
+  delegate: (config, req, res, session, cookie) => (
+    new Controller(config, req, res, session, cookie)),
 };

--- a/lib/controller/library/cookie.js
+++ b/lib/controller/library/cookie.js
@@ -4,21 +4,20 @@ const signature = require('cookie-signature');
 
 module.exports = config => ({
   set: (req, res, key, val, opts) => {
-    opts = opts || {}; // eslint-disable-line no-param-reassign
+    const item = opts || {};
     const signed = `${config.cfg.cookie.signPrefix}${signature.sign(val || '', config.cfg.cookie.secret)}`;
 
-    if (opts.expires === undefined) {
+    if (item.expires === undefined) {
       if (config.cfg.cookie.volatility) {
-        opts.expires = 0; // eslint-disable-line no-param-reassign
+        item.expires = 0;
       } else {
-        // eslint-disable-next-line no-param-reassign
-        opts.expires = new Date(Date.now() + (config.cfg.cookie.ttl * 1000));
+        item.expires = new Date(Date.now() + config.cfg.cookie.ttl * 1e3);
       }
     }
 
-    opts.sameSite = true; // eslint-disable-line no-param-reassign
+    item.sameSite = true;
 
-    res.cookie(key, signed, opts);
+    res.cookie(key, signed, item);
 
     return true;
   },

--- a/lib/controller/library/pagination.js
+++ b/lib/controller/library/pagination.js
@@ -2,6 +2,7 @@
 
 const qs = require('querystring');
 
+const escapeHTML = x => x.replace('&', '&amp;').replace('"', '&quot;');
 const paginator = {
   tag: (page, path, params, text, tag, cls, key) => {
     if (path === null) {
@@ -10,10 +11,10 @@ const paginator = {
 
     let query = qs.stringify(params);
     query = `${key}=${page}${query ? `&${query}` : ''}`;
-    path = `${path}?${query}`; // eslint-disable-line no-param-reassign
-    cls = cls ? ` class="${cls}"` : ''; // eslint-disable-line no-param-reassign
+    const href = escapeHTML(`${path}?${query}`);
+    const attrs = cls ? ` class="${escapeHTML(cls)}"` : '';
 
-    return `<${tag} href="${path}"${cls}>${text}</${tag}>`;
+    return `<${tag} href="${href}"${attrs}>${text}</${tag}>`;
   },
 };
 
@@ -26,9 +27,7 @@ module.exports = (req, res, opts, addOpts) => {
         && typeof opts[2] === 'number'
         && typeof opts[3] === 'number') {
       addOpts = addOpts || {};
-      addOpts.count = opts[0]; // eslint-disable-line prefer-destructuring
-      addOpts.page = opts[2]; // eslint-disable-line prefer-destructuring
-      addOpts.rpp = opts[3]; // eslint-disable-line prefer-destructuring
+      [addOpts.count, , addOpts.page, addOpts.rpp] = opts;
       opts = addOpts;
     }
   }
@@ -86,7 +85,7 @@ module.exports = (req, res, opts, addOpts) => {
         opts.first,
         opts.linkTag,
         opts.firstClass,
-        opts.key // eslint-disable-line comma-dangle
+        opts.key
       ));
     }
 
@@ -99,7 +98,7 @@ module.exports = (req, res, opts, addOpts) => {
       opts.prev,
       opts.linkTag,
       opts.prevClass,
-      opts.key // eslint-disable-line comma-dangle
+      opts.key
     ));
   }
 
@@ -121,7 +120,7 @@ module.exports = (req, res, opts, addOpts) => {
       opts.next,
       opts.linkTag,
       opts.nextClass,
-      opts.key // eslint-disable-line comma-dangle
+      opts.key
     ));
 
     // Last
@@ -133,7 +132,7 @@ module.exports = (req, res, opts, addOpts) => {
         opts.last,
         opts.linkTag,
         opts.lastClass,
-        opts.key // eslint-disable-line comma-dangle
+        opts.key
       ));
     }
   }

--- a/lib/controller/library/session.js
+++ b/lib/controller/library/session.js
@@ -11,20 +11,20 @@ module.exports = (config) => {
     return null;
   }
 
-  const sidKey = config.cfg.session.cookieName;
-  const sidLen = config.cfg.session.keyLength;
-  const rawLen = Math.ceil(sidLen * 0.75);
-
   const cache = cacheLib.init(cacheSessionKey, config.cfg.session);
 
-  const clearSessionId = (req, res) => { // eslint-disable-line no-unused-vars
+  const clearSessionId = (req, _res) => {
     delete req.sessionID;
-    delete req.cookies[sidKey];
+    delete req.cookies[config.cfg.session.cookieName];
   };
 
   const setSessionId = (req, res, sessionid) => {
     if (sessionid) clearSessionId(req, res);
-    else sessionid = randomBytes(rawLen).toString('base64').substring(0, sidLen); // eslint-disable-line no-param-reassign
+    else {
+      const len = config.cfg.session.keyLength;
+      const ral = len - Math.floor(len * 0.25);
+      sessionid = randomBytes(ral).toString('base64').substring(0, len); // eslint-disable-line no-param-reassign
+    }
 
     const signed = `${config.cfg.session.signPrefix}${signature.sign(sessionid, config.cfg.session.secret)}`;
     let expires;
@@ -32,7 +32,7 @@ module.exports = (config) => {
     if (config.cfg.session.volatility) {
       expires = 0;
     } else {
-      expires = new Date(Date.now() + (config.cfg.session.ttl * 1000));
+      expires = new Date(Date.now() + config.cfg.session.ttl * 1e3);
     }
 
     const options = {
@@ -40,7 +40,7 @@ module.exports = (config) => {
       sameSite: true,
     };
 
-    res.cookie(sidKey, signed, options);
+    res.cookie(config.cfg.session.cookieName, signed, options);
     req.sessionID = sessionid;
 
     return sessionid;
@@ -54,12 +54,14 @@ module.exports = (config) => {
     let nsessionid;
 
     // Session ID from Signed Cookie
-    const val = req.cookies[sidKey];
+    const val = req.cookies[config.cfg.session.cookieName];
     const pfx = config.cfg.session.signPrefix;
     if (val && val.startsWith(pfx)) {
       try {
-        nsessionid = signature.unsign(val.substring(pfx), config.cfg.session.secret);
-      } catch (_) { } // eslint-disable-line no-empty
+        nsessionid = signature.unsign(val.substring(pfx.length), config.cfg.session.secret);
+      } catch (_) {
+        // Ignore invalid signature
+      }
     }
 
     // Generate New Session ID
@@ -75,20 +77,19 @@ module.exports = (config) => {
     return sessionId(req, res);
   };
 
-  const sessionizedKey = (req, res, key) => {
-    key = `${sessionId(req, res)}:${key}`; // eslint-disable-line no-param-reassign
-    return key;
-  };
+  const sessionizedKey = (req, res, key) => `${sessionId(req, res)}:${key}`;
 
   return {
     engine: () => cache,
     id: (req, res, renewOrSet) => {
-      if (typeof (renewOrSet) === 'string') {
-        return setSessionId(req, res, renewOrSet);
-      } if (renewOrSet === true) {
-        return renewSessionId(req, res);
+      switch (true) {
+        case typeof renewOrSet === 'string':
+          return setSessionId(req, res, renewOrSet);
+        case renewOrSet:
+          return renewSessionId(req, res);
+        default:
+          return sessionId(req, res);
       }
-      return sessionId(req, res);
     },
     set: (req, res, key, val, ttl) => {
       ttl = ttl || config.cfg.session.ttl; // eslint-disable-line no-param-reassign

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -25,28 +25,30 @@ const applyPath = (baseParts, relParts) => {
     switch (part) {
       case '': case '.': break;
       case '..':
+        /* eslint-disable no-continue */
         switch (len) {
           case 0: break;
           case 1:
             if (bp[0] !== '' && bp[0] !== '..') {
               bp[0] = '';
-              continue; // eslint-disable-line no-continue
+              continue;
             }
             break;
           case 2:
             if (bp[0] === '') {
               bp[1] = '';
-              continue; // eslint-disable-line no-continue
+              continue;
             }
           /* fallthrough */
           default:
             if (bp[len - 1] !== '..') {
               if (len === 1) bp[0] = '';
               else bp.length = len - 1;
-              continue; // eslint-disable-line no-continue
+              continue;
             }
             break;
         }
+        /* eslint-enable no-continue */
       /* fallthrough */
       default:
         if (bp[len - 1] !== '') {
@@ -80,7 +82,9 @@ const joinPathNaive = (a, b) => {
     case 2: return `${a}${b.substring(1)}`;
   }
 };
+const NON_SLASH_RE = /[^/]/g;
+const countSlashes = a => `${a}`.replace(NON_SLASH_RE, '').length;
 
 module.exports = {
-  isArrowFunction, getRequireExt, applyPath, joinPathNaive,
+  isArrowFunction, getRequireExt, applyPath, joinPathNaive, countSlashes,
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -4,7 +4,7 @@ const dpJobError = require('./misc/dp_job_error');
 
 const getExitFunc = (exitCode) => {
   const k = typeof exitCode !== 'undefined' ? exitCode : 1;
-  return _ => process.exit(k); // eslint-disable-line no-unused-vars
+  return () => process.exit(k);
 };
 
 const succ = getExitFunc(0);
@@ -21,16 +21,14 @@ module.exports = (config) => {
     if (typeof handler.error !== 'function') return null;
 
     const exit = getExitFunc(global.DP_NODE_JOB_UNCAUGHT_FATAL_EXCEPTION_CODE);
-    const errObj = new dpJobError(err); // eslint-disable-line new-cap
+    const errObj = new dpJobError(err);
 
     return handler.error(asyncDp, errObj, null)
       .then(exit, (e) => {
-        console.error(e); // eslint-disable-line no-console
-        return exit(e);
+        console.error(e);
+        return exit();
       });
   };
 
-  // No need to test whether delegate is an AsyncFunction
-  // since Promise joins (follows) them automatically
   return delegate => new Promise(resolve => resolve(delegate(asyncDp))).then(succ, fail);
 };

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* eslint-disable no-underscore-dangle */
+/* eslint no-use-before-define: ["error", { "functions": false }] */
 const fs = require('fs');
 const path = require('path');
 const camelize = require('camelcase');
@@ -8,13 +8,9 @@ const decamelize = require('decamelize');
 const isCallable = require('is-callable');
 const { isArrowFunction } = require('./functions');
 
-const hasOwn = Object.prototype.hasOwnProperty;
-const nameVariationsOf = n => [n, camelize(n), decamelize(n)];
-
 const tryRequire = (pathloc, method) => {
   const joinedPath = path.join(pathloc, method);
   try {
-    // eslint-disable-next-line import/no-dynamic-require, global-require
     const module = require(joinedPath);
     if (module == null) throw new Error(`require(${JSON.stringify(joinedPath)}) returned ${module}`);
     return { module, method, found: true };
@@ -31,14 +27,13 @@ const tryRequire = (pathloc, method) => {
 };
 
 const newHiddenRoPropDesc = value => ({
-  configurable: true, enumerable: false, writable: false, value,
+  value, writable: false, enumerable: false, configurable: true,
 });
 const newVisibleRwPropDesc = value => ({
-  configurable: true, enumerable: true, writable: true, value,
+  value, writable: true, enumerable: true, configurable: true,
 });
 
 const fnBind = Function.prototype.bind;
-/* eslint-disable comma-dangle */
 const applyModule = (dest, module, argsNormal, argsArrow) => (
   Object.entries(module).forEach(([name, val]) => (
     Object.defineProperty(dest, name, newVisibleRwPropDesc(
@@ -48,73 +43,92 @@ const applyModule = (dest, module, argsNormal, argsArrow) => (
   ))
 );
 
-/* eslint-enable comma-dangle */
 const loadedProxies = Object.create(null);
 const parentRefPropDesc = (propName, parentName) => (
-  hasOwn.call(loadedProxies, parentName) ? newHiddenRoPropDesc(loadedProxies[parentName]) : {
-    configurable: true,
-    enumerable: false,
+  parentName in loadedProxies ? newHiddenRoPropDesc(loadedProxies[parentName]) : {
     get() {
-      if (hasOwn.call(loadedProxies, parentName)) {
+      if (parentName in loadedProxies) {
         const value = loadedProxies[parentName];
         Object.defineProperty(this, propName, newHiddenRoPropDesc(value));
         return value;
       }
       return undefined;
     },
+    enumerable: false,
+    configurable: true,
   }
 );
-const loader = (delegate, pathloc, exportKey) => {
-  let loaded;
-  const proxy = new Proxy(Object.prototype, {
-    get(target, method, receiver) {
-      if (method in target || typeof method !== 'string'
-          || !method || method === '.' || method === '..'
-          || method.indexOf('/') !== -1
-          || (path.sep !== '/' && method.indexOf(path.sep) !== -1)) {
-        return Reflect.get(target, method, receiver);
-      }
-      const nameVariations = nameVariationsOf(method);
 
-      let load = { module: null, method, found: false };
-      nameVariations.some((m) => {
-        const loadRes = tryRequire(pathloc, m);
-        const done = loadRes.module != null;
-        if (done || (!load.found && loadRes.found)) load = loadRes;
-        return done;
-      });
+const ReflectGet = Reflect.get;
+const { getPrototypeOf } = Object;
+const symDelegate = Symbol('dp-node.delegate');
+const symPath = Symbol('dp-node.path');
+const symExportKey = Symbol('dp-node.exportKey');
+const proxy = new Proxy(Object.prototype, {
+  get(target, method, receiver) {
+    if (proxy === receiver || method in target || typeof method !== 'string'
+        || !method || method === '.' || method === '..'
+        || method.indexOf('/') !== -1
+        || (path.sep !== '/' && method.indexOf(path.sep) !== -1)) {
+      return ReflectGet(target, method, receiver);
+    }
+    let loaded = receiver;
+    for (;;) {
+      const proto = getPrototypeOf(loaded);
+      if (proto === proxy) break;
+      loaded = proto;
+    }
 
-      const subDir = path.join(pathloc, load.method);
-      const result = loader(delegate, subDir);
-      if (load.module != null) {
-        const props = {
-          _: {
-            configurable: false, enumerable: false, writable: false, value: result,
-          },
-          __: {
-            configurable: false, enumerable: false, writable: false, value: loaded,
-          },
-        };
-        const that = Object.freeze(Object.create(delegate, props));
-        const it = exportKey == null ? that
-          : Object.freeze(Object.create(delegate[exportKey], props));
-        const argsNormal = [that];
-        const argsArrow = [null, it];
-        applyModule(result, load.module, argsNormal, argsArrow);
-      }
+    const { [symDelegate]: delegate, [symPath]: pathloc, [symExportKey]: exportKey } = loaded;
+    const nameVariations = Object.keys({
+      [method]: 1,
+      [camelize(method)]: 1,
+      [decamelize(method)]: 1,
+    });
 
-      const resultDesc = newVisibleRwPropDesc(result);
-      nameVariations.forEach(m => Object.defineProperty(loaded, m, resultDesc));
+    let load = { module: null, method, found: false };
+    nameVariations.some((m) => {
+      const loadRes = tryRequire(pathloc, m);
+      const done = loadRes.module != null;
+      if (done || (!load.found && loadRes.found)) load = loadRes;
+      return done;
+    });
 
-      return result;
-    },
-  });
+    const subDir = path.join(pathloc, load.method);
+    const result = loader(delegate, subDir);
+    if (load.module != null) {
+      const props = {
+        _: {
+          value: result, writable: false, enumerable: false, configurable: false,
+        },
+        __: {
+          value: loaded, writable: false, enumerable: false, configurable: false,
+        },
+      };
+      const that = Object.freeze(Object.create(delegate, props));
+      const it = exportKey == null ? that
+        : Object.freeze(Object.create(delegate[exportKey], props));
+      const argsNormal = [that];
+      const argsArrow = [null, it];
+      applyModule(result, load.module, argsNormal, argsArrow);
+    }
 
+    const resultDesc = newVisibleRwPropDesc(result);
+    nameVariations.forEach(m => Object.defineProperty(loaded, m, resultDesc));
+
+    return result;
+  },
+});
+function loader(delegate, pathloc, exportKey) {
   // Cache submodules by prototyping, plus lazy cacheing of '__'
-  loaded = Object.create(proxy, { __: parentRefPropDesc('__', path.dirname(pathloc)) });
+  const loaded = Object.create(proxy, {
+    [symDelegate]: newHiddenRoPropDesc(delegate),
+    [symPath]: newHiddenRoPropDesc(pathloc),
+    [symExportKey]: newHiddenRoPropDesc(exportKey),
+    __: parentRefPropDesc('__', path.dirname(pathloc)),
+  });
 
   Object.defineProperty(loadedProxies, pathloc, newVisibleRwPropDesc(loaded));
   return loaded;
-};
-
+}
 module.exports = loader;

--- a/lib/misc/dp_error.js
+++ b/lib/misc/dp_error.js
@@ -1,20 +1,24 @@
 'use strict';
 
-const DPError = function DPError(msg, req) {
-  this.name = this.constructor.name;
-
+function DPError(msg, req) {
   if (msg instanceof Error) {
-    this.code = msg.code;
     this.stack = msg.stack;
     this.message = msg.message;
-    this.req = req;
+    this.code = msg.code;
     this.originalError = msg;
   } else {
     Error.captureStackTrace(this, this.constructor);
 
     this.message = msg;
-    this.req = req;
   }
-};
+
+  this.req = req;
+}
+Object.defineProperty(DPError.prototype, 'name', {
+  value: 'DPError',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 module.exports = DPError;

--- a/lib/misc/dp_job_error.js
+++ b/lib/misc/dp_job_error.js
@@ -1,18 +1,22 @@
 'use strict';
 
-const DPJobError = function DPJobError(err) {
-  this.name = this.constructor.name;
-
+function DPJobError(err) {
   if (err instanceof Error) {
-    this.code = err.code;
     this.stack = err.stack;
     this.message = err.message;
+    this.code = err.code;
     this.originalError = err;
   } else {
     Error.captureStackTrace(this, this.constructor);
 
     this.message = err;
   }
-};
+}
+Object.defineProperty(DPJobError.prototype, 'name', {
+  value: 'DPJobError',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
 
 module.exports = DPJobError;

--- a/lib/model/engine.js
+++ b/lib/model/engine.js
@@ -5,27 +5,18 @@ const knexQb = require('knex/lib/query/builder');
 const knexRaw = require('knex/lib/raw');
 
 // Override
-const knexSelect = knexQb.prototype.select;
-const selectWithPrefix = (field, prefix) => {
-  if (typeof field === 'object') {
-    return field.map((e) => {
-      const pos = e.toLowerCase().indexOf(' as ');
-
-      return pos === -1 ? e : `${e.substr(0, pos)} AS ${prefix}_${e.substr(pos + 4)}`;
-    });
-  }
-
-  return field;
-};
 
 // Override - select
+const AS_RE = /\bas\s*[\s`'"]/i;
+const knexSelect = knexQb.prototype.select;
 knexQb.prototype.select = function select(field, prefix) {
   if (typeof field === 'object' && prefix) {
     if (!this.selectGroups) {
       this.selectGroups = [];
     }
     this.selectGroups.push(prefix);
-    return knexSelect.call(this, selectWithPrefix(field, prefix));
+    const replacement = `$&${prefix.replace('$', '$$$$')}_`;
+    field = field.map(e => e.replace(AS_RE, replacement)); // eslint-disable-line no-param-reassign
   }
 
   return knexSelect.call(this, field);
@@ -36,11 +27,11 @@ const knexUpdate = knexQb.prototype.update;
 
 const prepareParam = (data) => {
   if (data && typeof data === 'object') {
-    let ignorable = false;
-
-    ignorable = ignorable || data instanceof knexRaw;
-    ignorable = ignorable || data instanceof Date;
-    ignorable = ignorable || data instanceof Buffer;
+    const ignorable = (false
+      || data instanceof knexRaw
+      || data instanceof Date
+      || data instanceof Buffer
+    );
 
     if (!ignorable) {
       return String(data);
@@ -107,16 +98,24 @@ const prepareParamsForMixed = (args) => {
   }
 };
 
+const { getPrototypeOf } = Object;
+const fnApply = Function.prototype.call.bind(Function.prototype.apply);
 overridableKnexMethods.forEach((method) => {
+  /* eslint-disable prefer-rest-params */
   function override() {
     if ((this.client.config.options || {}).bindObjectAsString) {
-      prepareParamsForMixed(arguments); // eslint-disable-line prefer-rest-params
+      prepareParamsForMixed(arguments);
     }
 
-    // eslint-disable-next-line prefer-rest-params
-    return override.super.apply(this, arguments);
+    return fnApply(getPrototypeOf(override), this, arguments);
   }
-  override.super = knexQb.prototype[method];
+  /* eslint-enable prefer-rest-params */
+  const sup = knexQb.prototype[method];
+  Object.setPrototypeOf(override, sup); // XXX
+  Object.defineProperties(override, {
+    name: Object.getOwnPropertyDescriptor(sup, 'name'),
+    length: Object.getOwnPropertyDescriptor(sup, 'length'),
+  });
   knexQb.prototype[method] = override;
 });
 
@@ -135,19 +134,18 @@ const db = {
     if (typeof dsn === 'string') {
       key = dsn;
     } else if (dsn.key) {
-      key = dsn.key; // eslint-disable-line prefer-destructuring
+      ({ key } = dsn);
     } else {
       key = `${dsn.client}|${dsn.connection.database}|${dsn.connection.host}|${dsn.connection.user}`;
     }
 
-    if (db._conn[key]) { // eslint-disable-line no-underscore-dangle
-      return db._conn[key]; // eslint-disable-line no-underscore-dangle
+    if (db._conn[key]) {
+      return db._conn[key];
     }
 
-    // eslint-disable-next-line
     db._conn[key] = require('knex')(dsn);
 
-    return db._conn[key]; // eslint-disable-line no-underscore-dangle
+    return db._conn[key];
   },
   knex: dsn => db.conn(dsn),
   tran: (blocks, dsn) => {
@@ -166,10 +164,10 @@ const db = {
 
         return null;
       }))
-      .then(_ => results); // eslint-disable-line no-unused-vars
+      .then(_ => results);
   },
   execute: (query, params, dsn) => {
-    if (dsn === undefined && params) {
+    if (typeof dsn === 'undefined' && params) {
       dsn = params; // eslint-disable-line no-param-reassign
       params = undefined; // eslint-disable-line no-param-reassign
     }
@@ -193,7 +191,7 @@ const db = {
         let prefix = prefixes.filter(p => e.startsWith(`${p}_`));
 
         if (prefix.length > 0) {
-          prefix = prefix[0]; // eslint-disable-line prefer-destructuring
+          ([prefix] = prefix);
           obj[prefix] = obj[prefix] || {};
           obj[prefix][e.substr(prefix.length + 1)] = row[e];
         } else {
@@ -214,7 +212,7 @@ const db = {
     page = parseInt(page, 10) || 1; // eslint-disable-line no-param-reassign
     rpp = parseInt(rpp, 10) || 20; // eslint-disable-line no-param-reassign
 
-    const select = knex._statements // eslint-disable-line no-underscore-dangle
+    const select = knex._statements
       .reduce((a, e) => (e.grouping === 'columns' ? e.value.concat(a) : a), []);
 
     const knexCount = knex.clone().clearSelect().count('* AS cnt');

--- a/lib/model/index.js
+++ b/lib/model/index.js
@@ -20,10 +20,9 @@ module.exports = (config) => {
 
   // Assign engine when test mode enabled.
   if (global.isTest) {
-    global.__dpModelEngine__ = engine; // eslint-disable-line no-underscore-dangle
+    global.__dpModelEngine__ = engine;
   }
 
-  // eslint-disable-next-line global-require
   const loader = require('../loader')(delegate, `${config.cfg.apppath}/model`);
   delegate.model = loader;
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -27,7 +27,9 @@ const propGetAlts = (o, ...keys) => {
   }
   return undefined;
 };
-const { getRequireExt, applyPath, joinPathNaive } = functions;
+const {
+  getRequireExt, applyPath, joinPathNaive, countSlashes,
+} = functions;
 const isArrowFunction = ((m, f) => (x) => {
   let v = m.get(x);
   if (v == null) m.set(x, v = f(x));
@@ -90,13 +92,12 @@ const autoRegisterMiddlewares = (delegates, config) => {
     const name = basename.substring(0, basename.length - extension.length);
     if (hasOwn.call(specialMiddlewareFileNames, name)) {
       const registry = specialMiddlewareFileNames[name];
-      // eslint-disable-next-line import/no-dynamic-require, global-require
       let middleware = require(filePath);
       if (name === '_' || name === '__') middleware = fn2Sngltn(middleware);
       return registry.unshift([path.slice(0, -(name.length + 1)), middleware]); // tail call
     }
 
-    const routes = require(filePath); // eslint-disable-line
+    const routes = require(filePath);
     const middlewareForGlobal = findMiddleware(globalMiddlewaresFirst, path);
     const middlewareForGlobalEnd = findMiddleware(globalMiddlewaresEnd, path);
     const controllerForGlobal = findMiddleware(globalControllerFirst, path);
@@ -151,7 +152,6 @@ const autoRegisterMiddlewares = (delegates, config) => {
     try {
       if (!fs.statSync(dirPath).isDirectory()) return undefined;
     } catch (e) {
-      // eslint-disable-next-line no-console
       return console.error('Controller path load error, %s: %O', dirPath, e); // tail call
     }
 
@@ -214,17 +214,16 @@ const autoRegisterMiddlewares = (delegates, config) => {
   } = delegates;
   trees.reduce(
     (pps, e) => ((pps[+(e[1].indexOf(':') !== -1)].push(e), pps)),
-    [[], []] /* [ Only paths, Parameter paths ] */ // eslint-disable-line comma-dangle
+    [[], []] /* [ Only paths, Parameter paths ] */
   ).forEach(paths => (
-    paths.sort(([a], [b]) => b.split('/').length - a.split('/').length || (b > a) - (b < a))
+    paths.sort(([a], [b]) => countSlashes(b) - countSlashes(a) || (b > a) - (b < a))
       .forEach(e => route(...e))));
 
-  config.app.use((req, res, next) => { // eslint-disable-line no-unused-vars
+  config.app.use((req, res, _next) => {
     const ctrl = controller.delegate(config, req, res, session, cookie);
     const errorHandlerGlobal = findMiddleware(globalErrorHandler, req.url);
 
     if (typeof errorHandlerGlobal !== 'function') {
-      // eslint-disable-next-line new-cap
       controller.handler.serverError(ctrl, req, res, config, new dpError('404 Not Found', req), 404);
       return;
     }
@@ -239,12 +238,12 @@ const autoRegisterMiddlewares = (delegates, config) => {
 
       middlewarePostproc(req, res);
     }, (e) => {
-      console.error(e); // eslint-disable-line no-console
+      console.error(e);
 
-      const err = new dpError(e, req); // eslint-disable-line new-cap
+      const err = new dpError(e, req);
       err.message = '404 Not Found';
       controller.handler.serverError(ctrl, req, res, config, err, 404);
-    }).catch(e => console.error(e)); // eslint-disable-line no-console
+    }).catch(e => console.error(e));
   });
 };
 
@@ -261,7 +260,7 @@ module.exports = (config) => {
 
   // Assign engine when test mode enabled.
   if (global.isTest) {
-    global.__dpSessionEngine__ = session; // eslint-disable-line no-underscore-dangle
+    global.__dpSessionEngine__ = session;
   }
 
   const bodyParseRequiredMethods = { post: true, put: true, delete: true };
@@ -273,7 +272,7 @@ module.exports = (config) => {
     return Promise.resolve(delegate.apply(ctrl, args));
   };
 
-  const middlewarePostproc = (req, res, next) => { // eslint-disable-line no-unused-vars
+  const middlewarePostproc = (req, res, _next) => {
     if (res.bufferRedirect) {
       if (res.bufferRedirect.code) {
         res.redirect(res.bufferRedirect.url, res.bufferRedirect.code);
@@ -299,7 +298,7 @@ module.exports = (config) => {
       middlewaresEnd,
       controllerPrefix,
       controllerSuffix,
-      controllerErrorHandler // eslint-disable-line comma-dangle
+      controllerErrorHandler
     ) {
       const params = [path];
 
@@ -318,7 +317,7 @@ module.exports = (config) => {
 
             return new Promise(resolve => resolve(callback(handlerObj)))
               .catch((err) => {
-                const errObj = new dpError(err, req); // eslint-disable-line new-cap
+                const errObj = new dpError(err, req);
                 return controller.handler.serverError(ctrl, req, res, config, errObj, 500);
               });
           };
@@ -362,7 +361,7 @@ module.exports = (config) => {
           }
 
           const ctrl = controller.delegate(config, req, res, session, cookie);
-          const error = new dpError(err, req); // eslint-disable-line new-cap
+          const error = new dpError(err, req);
           controller.handler.serverError(ctrl, req, res, config, error, 500);
         }));
 
@@ -398,10 +397,9 @@ module.exports = (config) => {
       }
 
       // Postprocess and global error handling
-      // eslint-disable-next-line no-unused-vars
-      params.push(middlewarePostproc, (err, req, res, next) => {
+      params.push(middlewarePostproc, (err, req, res, _next) => {
         const ctrl = controller.delegate(config, req, res, session, cookie);
-        const error = new dpError(err, req); // eslint-disable-line new-cap
+        const error = new dpError(err, req);
         controller.handler.serverError(ctrl, req, res, config, error, 500);
       });
 

--- a/lib/static/js/dp.helper.js
+++ b/lib/static/js/dp.helper.js
@@ -5,27 +5,27 @@
 if (!dp) var dp = {};
 
 dp.helper = {
-  prefixize(path, prefix) {
+  prefixize: function (path, prefix) {
     prefix = prefix || dp.vars.prefix;
 
     if (prefix) {
       if (dp.helper.string.endsWith(prefix, '/')) {
-        prefix = prefix.substr(0, prefix.length - 1);
+        prefix = prefix.slice(0, -1);
       }
     } else {
       prefix = '';
     }
 
     if (dp.helper.string.startsWith(path, prefix)) {
-      path = path.substr(prefix.length) || '/';
+      path = path.substring(prefix.length) || '/';
     }
 
     return path;
   },
   req_busy: {},
-  req(obj, obj_add) {
+  req: function (obj, obj_add) {
     if (obj instanceof dp_jqlib) {
-      const _obj = obj;
+      var _obj = obj;
       obj = {
         url: _obj.attr('action'),
         type: _obj.attr('method'),
@@ -34,8 +34,8 @@ dp.helper = {
         fields: {},
       };
 
-      const objSucc = _obj.attr('dp-req-success');
-      const objError = _obj.attr('dp-req-error');
+      var objSucc = _obj.attr('dp-req-success');
+      var objError = _obj.attr('dp-req-error');
 
       if (objSucc) {
         obj.success = eval(objSucc);
@@ -46,7 +46,7 @@ dp.helper = {
       }
 
       if (_obj.find('*[dp-req-type="button"]').length > 0) {
-        const _btn = dp_jqlib(_obj.find('*[dp-req-type="button"]').get(0));
+        var _btn = dp_jqlib(_obj.find('*[dp-req-type="button"]').get(0));
 
         obj.button = _btn;
         obj.fade = _btn.attr('dp-req-fade') != 'no' && _btn.attr('dp-req-fade') != 'false';
@@ -62,14 +62,14 @@ dp.helper = {
       }
 
       _obj.find('*[dp-req-type]').each(function (i, e) {
-        const _this = dp_jqlib(this);
-        const key = _this.attr('name') || _this.attr('id');
-        const payload = {
+        var _this = dp_jqlib(this);
+        var key = _this.attr('name') || _this.attr('id');
+        var payload = {
           obj: _this,
           required: _this.attr('dp-req-required') == 'yes' || _this.attr('dp-req-required') == 'true',
           focus: _this.attr('dp-req-required') == 'yes' || _this.attr('dp-req-required') == 'true',
           validate: _this.attr('dp-req-type'),
-          length: _this.attr('dp-req-length') ? dp_jqlib.map(_this.attr('dp-req-length').split(','), (v, i) => parseInt(v, 10)) : undefined,
+          length: _this.attr('dp-req-length') ? dp_jqlib.map(_this.attr('dp-req-length').split(','), function (v) { return parseInt(v, 10); }) : undefined,
           message: {
             missing: _this.attr('dp-req-missing'),
             invalid: _this.attr('dp-req-invalid'),
@@ -95,19 +95,19 @@ dp.helper = {
       dp_jqlib.extend(obj, obj_add);
     }
 
-    const btn = obj.button || undefined;
-    const multiple = obj.multiple || false;
-    const fields = obj.fields || [];
-    const url = obj.url || undefined;
-    const headers = obj.headers || undefined;
-    const type = obj.type || 'POST';
-    const data = obj.data || {};
-    const dataType = obj.dataType || 'json';
-    const fade = obj.fade != undefined ? obj.fade : true;
-    const prefixize = obj.prefixize != undefined ? obj.prefixize : true;
-    const prefix = obj.prefix != undefined ? obj.prefix : dp.vars.prefix;
-    let identifier = obj.identifier || undefined;
-    const opacity_origin = btn ? btn.css('opacity') : 1.0;
+    var btn = obj.button || undefined;
+    var multiple = obj.multiple || false;
+    var fields = obj.fields || [];
+    var url = obj.url || undefined;
+    var headers = obj.headers || undefined;
+    var type = obj.type || 'POST';
+    var data = obj.data || {};
+    var dataType = obj.dataType || 'json';
+    var fade = obj.fade != undefined ? obj.fade : true;
+    var prefixize = obj.prefixize != undefined ? obj.prefixize : true;
+    var prefix = obj.prefix != undefined ? obj.prefix : dp.vars.prefix;
+    var identifier = obj.identifier || undefined;
+    var opacity_origin = btn ? btn.css('opacity') : 1.0;
 
     if (btn && !btn.attr('id')) {
       btn.attr('id', `temp-${dp.helper.string.uniqid()}`);
@@ -120,8 +120,8 @@ dp.helper = {
     if (!multiple && dp.helper.req_busy[identifier]) return false;
     dp.helper.req_busy[identifier] = true;
 
-    let no_finalize = false;
-    const fn_finalize = function () {
+    var no_finalize = false;
+    var fn_finalize = function () {
       if (no_finalize) {
         no_finalize = false;
         return;
@@ -140,17 +140,17 @@ dp.helper = {
       }
     }
 
-    let fields_checked = true;
-    let output = false;
+    var fields_checked = true;
+    var output = false;
 
-    dp_jqlib.each(fields, (key, e) => {
-      let val = e.val;
+    dp_jqlib.each(fields, function (key, e) {
+      var val = e.val;
 
       if (val === undefined && e.obj) {
         val = e.obj.val();
       }
 
-      let skip = false;
+      var skip = false;
 
       // Required
       if (fields_checked && e.required && !val) {
@@ -196,8 +196,8 @@ dp.helper = {
       if (fields_checked && e.message && e.message.confirm && !e.message.confirming) {
         e.message.confirming = true;
 
-        const confirmYes = e.message.confirmYes || 'OK';
-        const confirmNo = e.message.confirmNo || 'Cancel';
+        var confirmYes = e.message.confirmYes || 'OK';
+        var confirmNo = e.message.confirmNo || 'Cancel';
 
         output = dp.alert(
           e.message.confirm,
@@ -229,9 +229,9 @@ dp.helper = {
       return output;
     }
 
-    const finalize = function (data) {
+    var finalize = function (data) {
       if (data && typeof data === 'object') {
-        const finalizePage = function () {
+        var finalizePage = function () {
           if (data.redirect) {
             document.location.href = data.redirect;
           } else if (data.reload) {
@@ -249,7 +249,7 @@ dp.helper = {
       }
     };
 
-    const success = function (res) {
+    var success = function (res) {
       if (dataType && dataType.toLowerCase() == 'json') {
         if (res.result != undefined && !res.result) {
           error(undefined, undefined, undefined, res);
@@ -276,8 +276,8 @@ dp.helper = {
       finalize(res);
     };
 
-    const ajax_req = function () {
-      const payload = {
+    var ajax_req = function () {
+      var payload = {
         url: prefixize ? dp.helper.prefixize(url, prefix) : url,
         headers,
         type,
@@ -301,22 +301,22 @@ dp.helper = {
     return true;
   },
   validator: {
-    email(e) {
-      const re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    email: function (e) {
+      var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
       return re.test(e);
     },
-    url(e, i) {
+    url: function (e, i) {
       if (!i && e.indexOf('http')) {
         return false;
       }
 
-      const re = new RegExp('^(?:(?:https?|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:22[0-3]|2[01]\\d|[1-9]\\d?|1\\d\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1?\\d{1,2})){2}(?:\\.(?:25[0-4]|2[0-4]\\d|1\\d\\d|[1-9]\\d?))|(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))(?::\\d{2,5})?(?:/\\S*)?$', 'i');
+      var re = new RegExp('^(?:(?:https?|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:22[0-3]|2[01]\\d|[1-9]\\d?|1\\d\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1?\\d{1,2})){2}(?:\\.(?:25[0-4]|2[0-4]\\d|1\\d\\d|[1-9]\\d?))|(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))(?::\\d{2,5})?(?:/\\S*)?$', 'i');
       return re.test(e);
     },
   },
   string: {
     _uniqid_seed: 0,
-    uniqid(prefix, more_entropy, more_entropy_separator) {
+    uniqid: function (prefix, more_entropy, more_entropy_separator) {
       /* This code has extracted from php.js */
 
       if (!prefix) {
@@ -327,8 +327,8 @@ dp.helper = {
         more_entropy_separator = '';
       }
 
-      let retId;
-      const formatSeed = (function (seed, reqWidth) {
+      var retId;
+      function formatSeed (seed, reqWidth) {
         seed = parseInt(seed, 10).toString(16);
 
         if (reqWidth < seed.length) {
@@ -336,12 +336,13 @@ dp.helper = {
         }
 
         if (reqWidth > seed.length) {
-          const arr = new Array(1 + (reqWidth - seed.length));
-          return arr.join('0') + seed;
+          var arr = [];
+          arr[reqWidth - seed.length] = seed;
+          return arr.join('0');
         }
 
         return seed;
-      });
+      }
 
       if (!dp.helper.string._uniqid_seed) {
         dp.helper.string._uniqid_seed = Math.floor(Math.random() * 0x75bcd15);
@@ -360,21 +361,21 @@ dp.helper = {
 
       return dp.helper.string.replaceAll(retId, '.', more_entropy_separator);
     },
-    replaceAll(text, find, replace) {
+    replaceAll: function (text, find, replace) {
       return text.split(find).join(replace);
     },
-    startsWith(str, prefix) {
+    startsWith: function (str, prefix) {
       return str ? str.indexOf(prefix, 0) !== -1 : false;
     },
-    endsWith(str, suffix) {
+    endsWith: function (str, suffix) {
       return str ? str.indexOf(suffix, str.length - suffix.length) !== -1 : false;
     },
-    extractNumbers(val) {
-      const replace = /[^0-9]/gi;
-      return (val.substring(0, 1) == '-' ? '-' : '') + val.replace(replace, '');
+    extractNumbers: function (val) {
+      var replace = /^(-)|[^0-9]/g;
+      return val.replace(replace, '$1');
     },
-    numberFormat(val) {
-      return val.toFixed(0).replace(/(\d)(?=(\d{3})+$)/g, '$1,');
+    numberFormat: function (val) {
+      return val.toFixed(0).replace(/(\d)(?=(?:\d{3})+$)/g, '$1,');
     },
   },
 };

--- a/lib/static/js/dp.js
+++ b/lib/static/js/dp.js
@@ -3,7 +3,7 @@
 /* eslint-disable */
 
 var dp = {
-  init() {
+  init: function () {
     if (dp.ui) {
       dp.ui.init();
     }
@@ -14,7 +14,7 @@ var dp = {
 
     },
   },
-  req(o, oa) {
+  req: function (o, oa) {
     if (!dp.helper) {
       alert('dp.helper library is required.');
       return false;
@@ -22,13 +22,14 @@ var dp = {
 
     return dp.helper.req(o, oa);
   },
-  alert(a, b, c, d, e, f, g) {
+  alert: function (a, b, c, d, e, f, g) {
     if (!dp.ui) {
       alert('dp.helper library is required.');
       return false;
     }
 
-    return dp.ui.util.alert(a, b, c, d, e, f, g);
+    var util = dp.ui.util;
+    return util.alert.apply(util, arguments);
   },
   noti(a, b, c, d) {
     if (!dp.ui) {
@@ -37,14 +38,14 @@ var dp = {
     }
 
     return dp.ui.util.noti(a, b, c, d);
-  },
+  }
 };
 
 try {
   dp.vars.prefix = dp_prefix || undefined;
 } catch (e) { }
-let dp_jqlib = false;
-const dp_init = function (fn) {
+var dp_jqlib = false;
+var dp_init = function (fn) {
   'use strict';
   if (!dp_jqlib) return;
   dp_jqlib(fn);
@@ -60,12 +61,13 @@ try {
 if (!dp_jqlib) {
   alert('jQuery >= 3.x library is required.');
 } else {
-  dp_init(() => {
+  dp_init(function () {
+    'use strict';
     dp.init();
   });
 }
 
-const _el = function (selector, no_cache) {
+var _el = function (selector, no_cache) {
   'use strict';
   if (!no_cache && dp.vars.cached[selector] != null) return dp.vars.cached[selector];
 

--- a/lib/static/js/dp.ui.js
+++ b/lib/static/js/dp.ui.js
@@ -6,7 +6,7 @@ if (!dp) var dp = {};
 
 dp.ui = {
   _initiated: false,
-  init(obj) {
+  init: function (obj) {
     if (!obj && dp.ui._initiated) return;
     dp.ui._initiated = true;
     dp.ui.element.init(obj);
@@ -14,12 +14,12 @@ dp.ui = {
   util: {
     _alert_template: undefined,
     alert_focus: undefined,
-    alert(a, b, c, d, e) {
+    alert: function (a, b, c, d, e) {
       if (dp.ui.util._alert_template == undefined) {
         dp.ui.util._alert_template = dp_jqlib('<div />').addClass('dp4css-alert');
         dp.ui.util._alert_template.append(dp_jqlib('<div />').addClass('_bg'));
 
-        const _box = dp_jqlib('<div />').addClass('_box');
+        var _box = dp_jqlib('<div />').addClass('_box');
 
         _box.append(dp_jqlib('<div />').addClass('_msg'));
         _box.append(dp_jqlib('<div />').addClass('_ico').text('!'));
@@ -28,17 +28,17 @@ dp.ui = {
         dp.ui.util._alert_template.append(_box);
       }
 
-      const template = dp.ui.util._alert_template.clone();
+      var template = dp.ui.util._alert_template.clone();
       template.attr('id', `uniqid-${dp.helper.string.uniqid()}`);
 
-      const bg = template.find('._bg');
-      const message = template.find('._msg');
-      const button = template.find('._btn');
-      const box = template.find('._box');
+      var bg = template.find('._bg');
+      var message = template.find('._msg');
+      var button = template.find('._btn');
+      var box = template.find('._box');
 
-      let _msg;
-      let _msg_html;
-      const _buttons = [];
+      var _msg;
+      var _msg_html;
+      var _buttons = [];
 
       if (typeof a === 'object' && !b && !c && !d && !e) {
         if (a.message && a.html) {
@@ -48,7 +48,7 @@ dp.ui = {
         }
 
         if (a.buttons) {
-          for (const i in a.buttons) {
+          for (var i in a.buttons) {
             _buttons.push([a.buttons[i][0], a.buttons[i][1]]);
           }
         }
@@ -90,11 +90,11 @@ dp.ui = {
         message.html(message.text().replace(/\n/gi, '<br />'));
       }
 
-      let box_height = 0;
-      const pongdang = 15;
-      let delegate;
+      var box_height = 0;
+      var pongdang = 15;
+      var delegate;
 
-      const _dismiss = function () {
+      var _dismiss = function () {
         box.animate({
           'margin-top': `${((box_height / 2) + 30) * -1}px`,
         }, 150, () => {
@@ -118,8 +118,8 @@ dp.ui = {
         });
       };
 
-      dp_jqlib(_buttons).each((k, e) => {
-        const btn = dp_jqlib('<button />');
+      dp_jqlib(_buttons).each(function (k, e) {
+        var btn = dp_jqlib('<button />');
         btn.addClass(`_i-${k}`);
         btn.text(e[0]);
         btn.click(() => {
@@ -137,7 +137,7 @@ dp.ui = {
 
       box_height = box.height();
 
-      const bg_opacity = parseFloat(bg.css('opacity'));
+      var bg_opacity = parseFloat(bg.css('opacity'));
 
       bg.fadeTo(0, 0.001);
       box.fadeTo(0, 0.001);
@@ -163,12 +163,12 @@ dp.ui = {
 
       return template;
     },
-    noti(a, b, c, d) {
+    noti: function (a, b, c, d) {
       alert('not implemented yet.');
     },
   },
   element: {
-    init(obj) {
+    init: function (obj) {
       dp.ui.element.input.delegate.on_return(obj);
       dp.ui.element.input.delegate.on_focus(obj);
       dp.ui.element.input.delegate.on_focusout(obj);
@@ -178,10 +178,10 @@ dp.ui = {
     },
     input: {
       delegate: {
-        on_return(obj) {
+        on_return: function (obj) {
           if (!obj) obj = dp_jqlib('body');
           obj.find('input[dp-on-return][dp-on-return-installed!=yes]').each(function () {
-            const _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
+            var _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
 
             dp_jqlib(this).attr('id', _id);
             dp_jqlib(this).attr('dp-on-return-installed', 'yes');
@@ -192,7 +192,7 @@ dp.ui = {
               }
 
               if (e.keyCode == 13) {
-                let delegate;
+                var delegate;
 
                 try {
                   delegate = eval(dp_jqlib(this).attr('dp-on-return'));
@@ -209,16 +209,16 @@ dp.ui = {
             });
           });
         },
-        on_focus(obj) {
+        on_focus: function (obj) {
           if (!obj) obj = dp_jqlib('body');
           obj.find('input[dp-on-focus][dp-on-focus-installed!=yes],textarea[dp-on-focus][dp-on-focus-installed!=yes]').each(function () {
-            const _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
+            var _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
 
             dp_jqlib(this).attr('id', _id);
             dp_jqlib(this).attr('dp-on-focus-installed', 'yes');
 
             dp_jqlib(this).focus(function (e) {
-              let delegate;
+              var delegate;
 
               try {
                 delegate = eval(dp_jqlib(this).attr('dp-on-focus'));
@@ -230,16 +230,16 @@ dp.ui = {
             });
           });
         },
-        on_focusout(obj) {
+        on_focusout: function (obj) {
           if (!obj) obj = dp_jqlib('body');
           obj.find('input[dp-on-focusout][dp-on-focusout-installed!=yes],textarea[dp-on-focusout][dp-on-focusout-installed!=yes]').each(function () {
-            const _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
+            var _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
 
             dp_jqlib(this).attr('id', _id);
             dp_jqlib(this).attr('dp-on-focusout-installed', 'yes');
 
             dp_jqlib(this).focusout(function (e) {
-              let delegate;
+              var delegate;
 
               try {
                 delegate = eval(dp_jqlib(this).attr('dp-on-focusout'));
@@ -251,16 +251,16 @@ dp.ui = {
             });
           });
         },
-        on_keyup(obj) {
+        on_keyup: function (obj) {
           if (!obj) obj = dp_jqlib('body');
           obj.find('input[dp-on-keyup][dp-on-keyup-installed!=yes],textarea[dp-on-keyup][dp-on-keyup-installed!=yes]').each(function () {
-            const _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
+            var _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
 
             dp_jqlib(this).attr('id', _id);
             dp_jqlib(this).attr('dp-on-keyup-installed', 'yes');
 
             dp_jqlib(this).keyup(function (e) {
-              let delegate;
+              var delegate;
               try {
                 delegate = eval(dp_jqlib(this).attr('dp-on-keyup'));
               } catch (_) {}
@@ -271,16 +271,16 @@ dp.ui = {
             });
           });
         },
-        on_keydown(obj) {
+        on_keydown: function (obj) {
           if (!obj) obj = dp_jqlib('body');
           obj.find('input[dp-on-keydown][dp-on-keydown-installed!=yes],textarea[dp-on-keydown][dp-on-keydown-installed!=yes]').each(function () {
-            const _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
+            var _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
 
             dp_jqlib(this).attr('id', _id);
             dp_jqlib(this).attr('dp-on-keydown-installed', 'yes');
 
             dp_jqlib(this).keydown(function (e) {
-              let delegate;
+              var delegate;
               try {
                 delegate = eval(dp_jqlib(this).attr('dp-on-keydown'));
               } catch (_) {}
@@ -291,22 +291,22 @@ dp.ui = {
             });
           });
         },
-        on_paste(obj) {
+        on_paste: function (obj) {
           if (!obj) obj = dp_jqlib('body');
           obj.find('input[dp-on-paste][dp-on-paste-installed!=yes],textarea[dp-on-paste][dp-on-paste-installed!=yes]').each(function () {
-            const _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
+            var _id = dp_jqlib(this).attr('id') || `uniqid-${dp.helper.string.uniqid()}`;
 
             dp_jqlib(this).attr('id', _id);
             dp_jqlib(this).attr('dp-on-paste-installed', 'yes');
 
             this.addEventListener('paste', function (e) {
-              let delegate;
+              var delegate;
               try {
                 delegate = eval(dp_jqlib(this).attr('dp-on-paste'));
               } catch (_) {}
 
               if (delegate && typeof delegate === 'function') {
-                let clipboardData; let pastedData;
+                var clipboardData; var pastedData;
 
                 try {
                   clipboardData = e.clipboardData || window.clipboardData;
@@ -323,6 +323,6 @@ dp.ui = {
   },
 };
 
-dp_init(() => {
+dp_init(function () {
   dp.init();
 });

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* global describe, before, after */
-/* eslint-disable no-underscore-dangle */
+/* eslint import/no-extraneous-dependencies: ["error", { "devDependencies": true }] */
 
 module.exports = {
   init(options) {
@@ -10,13 +10,13 @@ module.exports = {
     global.isTest = true;
 
     return (fn, app, title) => {
-      const supertest = require('supertest'); // eslint-disable-line
+      const supertest = require('supertest');
 
       describe(title || 'WebServer', () => {
         let http;
 
         before((done) => {
-          http = opts.isAppBind === false ? null : app.dp.listen();
+          http = opts.isAppBind !== false && app.dp.listen();
 
           const engine = global.__dpModelEngine__;
           if (engine.destroyed) {

--- a/lib/view/engine.js
+++ b/lib/view/engine.js
@@ -159,33 +159,28 @@ module.exports = (config) => {
     if (typeof fn === 'undefined') {
       fn = handlebarsP.compile(ast);
       Object.defineProperty(ast, compiledCache, {
-        configurable: true,
-        enumerable: false, /* so that Object.assign above doesn't copy this */
-        writable: false,
         value: fn,
+        writable: false,
+        enumerable: false, /* so that Object.assign above doesn't copy this */
+        configurable: true,
       });
     }
     return fn(params || {});
   });
 
   // Handlbars-Helpers
-  // eslint-disable-next-line global-require
   require('handlebars-helpers')({ handlebarsP });
 
   // Handlebars-Helper, Repeat
-  // eslint-disable-next-line global-require
   handlebarsP.registerHelper('repeat', require('handlebars-helper-repeat'));
 
   // Handlebars-Helper, nl2br
-  // eslint-disable-next-line global-require
   handlebarsP.registerHelper('nl2br', require('./helpers/nl2br')(handlebarsP));
 
   // Handlebars-Helper, pagingIdx
-  // eslint-disable-next-line global-require
   handlebarsP.registerHelper('pagingIdx', require('./helpers/pagingIdx'));
 
   // Handlebars-Helper, pagingItems
-  // eslint-disable-next-line global-require
   handlebarsP.registerHelper('pagingItems', require('./helpers/pagingItems'));
 
   Object.entries(config.cfg.viewHelpers).forEach(([helper, object]) => {

--- a/lib/view/helpers/nl2br.js
+++ b/lib/view/helpers/nl2br.js
@@ -5,7 +5,7 @@ module.exports = function nl2br(hbs) {
     str = hbs.escapeExpression(str); // eslint-disable-line no-param-reassign
     const breakTag = options.hash && options.hash.isXhtml ? '<br />' : '<br>';
     const isReplace = !!(options.hash && options.hash.replace);
-    const replaced = str.replace(/(\r?\n|\n?\r)/g, isReplace ? breakTag : `${breakTag}$1`);
+    const replaced = str.replace(/\r?\n|\r/g, isReplace ? breakTag : `${breakTag}$&`);
     return new hbs.SafeString(replaced);
   };
 };

--- a/lib/view/helpers/pagingIdx.js
+++ b/lib/view/helpers/pagingIdx.js
@@ -1,14 +1,11 @@
 'use strict';
 
 module.exports = (pager, index, rev) => {
-  const reverse = rev === true;
+  const reverse = rev == null || rev;
   const count = pager && pager[0] ? pager[0] : 0;
   const page = pager && pager[2] ? pager[2] : 1;
   const rpp = pager && pager[3] ? pager[3] : 1;
+  const base = (page - 1) * rpp + index;
 
-  if (reverse) {
-    return (page - 1) * rpp + index + 1; // eslint-disable-line no-mixed-operators
-  }
-
-  return count - ((page - 1) * rpp) - index; // eslint-disable-line no-mixed-operators
+  return reverse ? base + 1 : count - base;
 };

--- a/test/example/controller/_.js
+++ b/test/example/controller/_.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = (req, res, next) => {
-  res.async((dp) => { // eslint-disable-line no-unused-vars
+  res.async((_dp) => {
     next();
   });
 };

--- a/test/example/controller/middleware/file/_.js
+++ b/test/example/controller/middleware/file/_.js
@@ -1,7 +1,7 @@
 'use strict';
 
-module.exports = (req, res, next) => { // eslint-disable-line no-unused-vars
-  res.async((dp) => { // eslint-disable-line no-unused-vars
+module.exports = (req, res, _next) => {
+  res.async((_dp) => {
     res.status(200).send('file/middleware');
   });
 };

--- a/test/example/controller/middleware/file/child/grandchild/_.js
+++ b/test/example/controller/middleware/file/child/grandchild/_.js
@@ -1,7 +1,7 @@
 'use strict';
 
-module.exports = (req, res, next) => { // eslint-disable-line no-unused-vars
-  res.async((dp) => { // eslint-disable-line no-unused-vars
+module.exports = (req, res, _next) => {
+  res.async((_dp) => {
     res.status(200).send('file/child/grandchild/middleware');
   });
 };

--- a/test/example/controller/middleware/file/child3.js
+++ b/test/example/controller/middleware/file/child3.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  __: (req, res, next) => { // eslint-disable-line no-unused-vars
+  __: (req, res, _next) => {
     res.status(200).send('file/child3/middleware');
   },
   get: (controller) => {

--- a/test/example/controller/middleware/file/end/_.js
+++ b/test/example/controller/middleware/file/end/_.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = (req, res, next) => {
-  res.async((dp) => { // eslint-disable-line no-unused-vars
+  res.async((_dp) => {
     next();
   });
 };

--- a/test/example/controller/middleware/file/error/_.js
+++ b/test/example/controller/middleware/file/error/_.js
@@ -1,16 +1,23 @@
 'use strict';
 
-const CustomError = function CustomError(message) {
+const util = require('util');
+
+function CustomError(message) {
   Error.captureStackTrace(this, this.constructor);
 
-  this.name = this.constructor.name;
   this.message = message;
-};
+}
+util.inherits(CustomError, Error);
 
-require('util').inherits(CustomError, Error);
+Object.defineProperty(CustomError.prototype, 'name', {
+  value: 'CustomError',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
 
-module.exports = (req, res, next) => { // eslint-disable-line no-unused-vars
-  res.async((dp) => { // eslint-disable-line no-unused-vars
+module.exports = (req, res, _next) => {
+  res.async((_dp) => {
     throw new CustomError('/middleware/file/error/middleware');
   });
 };

--- a/test/example/controller/middleware/file/error2/_.js
+++ b/test/example/controller/middleware/file/error2/_.js
@@ -1,14 +1,21 @@
 'use strict';
 
-const CustomError = function CustomError(message) {
+const util = require('util');
+
+function CustomError(message) {
   Error.captureStackTrace(this, this.constructor);
 
-  this.name = this.constructor.name;
   this.message = message;
-};
+}
+util.inherits(CustomError, Error);
 
-require('util').inherits(CustomError, Error);
+Object.defineProperty(CustomError.prototype, 'name', {
+  value: 'CustomError',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
 
-module.exports = (req, res, next) => { // eslint-disable-line no-unused-vars
+module.exports = (_req, _res, _next) => {
   throw new CustomError('/middleware/file/error2/middleware');
 };

--- a/test/example/controller/middleware/file/not_async/__.js
+++ b/test/example/controller/middleware/file/not_async/__.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = (req, res, next) => { // eslint-disable-line no-unused-vars
+module.exports = (req, res, _next) => {
   res.status(200).send(`${res.testBegin}-${res.buffer.body}-${res.testController}`);
 };

--- a/test/example/controller/model/mysql/simple.js
+++ b/test/example/controller/model/mysql/simple.js
@@ -4,10 +4,11 @@ const assert = require('assert');
 
 module.exports = {
   async get() {
-    var create = await this.model.test.createTable() // eslint-disable-line
+    /* eslint-disable no-unused-vars */
+    const create = await this.model.test.createTable();
     const insert = await this.model.test.insertRecord();
     const inserted = await this.model.test.inquiryRecord();
-    var created2 = await this.model.test.knex.createTable() // eslint-disable-line
+    const created2 = await this.model.test.knex.createTable();
 
     assert(insert.insertId);
     assert(inserted.id && inserted.value);

--- a/test/example/error.js
+++ b/test/example/error.js
@@ -6,11 +6,11 @@ module.exports = async (controller, error, statusCode) => {
   // for async-await test
   const res = await controller.model.test.dummy();
 
-  assert(res && res['1'] === 1);
+  assert(res && res[1] === 1);
 
   // from Job exception.
   if (error.name === 'DPJobError') {
-    console.error('job exception'); // eslint-disable-line no-console
+    console.error('job exception');
     return;
   }
 

--- a/test/example/helper/bar.js
+++ b/test/example/helper/bar.js
@@ -3,12 +3,12 @@
 module.exports = {
   async barAsync() {
     return new Promise((resolve) => {
-      resolve(this.__.foo.bar()); // eslint-disable-line no-underscore-dangle
+      resolve(this.__.foo.bar());
     });
   },
-  bazAsync: async helper => helper.__.foo.baz(), // eslint-disable-line no-underscore-dangle
+  bazAsync: async helper => helper.__.foo.baz(),
   boz() {
-    return this.__.foo.boz; // eslint-disable-line no-underscore-dangle
+    return this.__.foo.boz;
   },
   qux() {
     return this.helper.foo.qux();

--- a/test/example/job/async_job.js
+++ b/test/example/job/async_job.js
@@ -12,5 +12,5 @@ require('../app')(async (dp) => {
   assert(insert.insertId);
   assert(inserted.id && inserted.value);
 
-  console.log('done'); // eslint-disable-line no-console
+  console.log('done');
 });

--- a/test/example/job/render_view.js
+++ b/test/example/job/render_view.js
@@ -4,5 +4,5 @@ global.mode = 'job';
 global.DP_NODE_JOB_UNCAUGHT_FATAL_EXCEPTION_CODE = 0;
 
 require('../app')(async (dp) => {
-  console.log(await dp.view.render('view/simple_render.html')); // eslint-disable-line no-console
+  console.log(await dp.view.render('view/simple_render.html'));
 });

--- a/test/example/job/test.js
+++ b/test/example/job/test.js
@@ -2,5 +2,5 @@
 
 global.mode = 'job';
 require('../app')(() => {
-  console.log('done'); // eslint-disable-line no-console
+  console.log('done');
 });

--- a/test/example/job/test_error.js
+++ b/test/example/job/test_error.js
@@ -1,8 +1,10 @@
 'use strict';
 
+/* global intended_exception */
+
 global.mode = 'job';
 global.DP_NODE_JOB_UNCAUGHT_FATAL_EXCEPTION_CODE = 0;
 
 require('../app')(() => {
-  console.log(intended_exception); // eslint-disable-line
+  console.log(intended_exception);
 });

--- a/test/example/model/test/group.js
+++ b/test/example/model/test/group.js
@@ -37,7 +37,7 @@ module.exports = {
       resPromised,
       pgPage,
       pgRpp,
-      this.grouping(['pfx']) // eslint-disable-line comma-dangle
+      this.grouping(['pfx'])
     );
 
     assert(pg[0]);

--- a/test/example/model/test/options.js
+++ b/test/example/model/test/options.js
@@ -72,7 +72,8 @@ module.exports = {
         .whereIn('value', [new Fn(1000), new Fn(1004)]);
 
       throw Error('No!');
-    } catch (_) { // eslint-disable-line no-empty
+    } catch (_) {
+      // dismiss
     }
 
     assert((await db.knex(`${global.stage}Opt`)

--- a/test/example/model/test/underscore.js
+++ b/test/example/model/test/underscore.js
@@ -5,6 +5,6 @@ module.exports = {
     return a + b;
   },
   dblUnderscore(a, b) {
-    return this.__.underscoreCalc(a, b); // eslint-disable-line no-underscore-dangle
+    return this.__.underscoreCalc(a, b);
   },
 };

--- a/test/example/model/test/uscore/baz/index.js
+++ b/test/example/model/test/uscore/baz/index.js
@@ -8,6 +8,6 @@ module.exports = {
     return this._;
   },
   koo() {
-    return this.__.bar.koo; // eslint-disable-line no-underscore-dangle
+    return this.__.bar.koo;
   },
 };

--- a/test/example/model/test/uscore/one/in_one/index.js
+++ b/test/example/model/test/uscore/one/in_one/index.js
@@ -2,6 +2,6 @@
 
 module.exports = {
   two() {
-    return this.__.__.two.one.three; // eslint-disable-line no-underscore-dangle
+    return this.__.__.two.one.three;
   },
 };

--- a/test/example/model/test/uscore/qux/index.js
+++ b/test/example/model/test/uscore/qux/index.js
@@ -2,19 +2,19 @@
 
 module.exports = {
   fao() {
-    return this.__.foo.fao(); // eslint-disable-line no-underscore-dangle
+    return this.__.foo.fao();
   },
   fred() {
     this._.quux.bark();
-    this.__.foo.fao(); // eslint-disable-line no-underscore-dangle
-    this.__.baz.koo(); // eslint-disable-line no-underscore-dangle
+    this.__.foo.fao();
+    this.__.baz.koo();
     return this._.quux.fred;
   },
   koo() {
-    return this.__.baz.koo(); // eslint-disable-line no-underscore-dangle
+    return this.__.baz.koo();
   },
   mos() {
-    this.model.test.uscore.qux.fred(); // eslint-disable-line no-underscore-dangle
-    return this.__.qux.quux.mos; // eslint-disable-line no-underscore-dangle
+    this.model.test.uscore.qux.fred();
+    return this.__.qux.quux.mos;
   },
 };


### PR DESCRIPTION
 * (README.md) change README a bit
 * (.eslintrc.js) adjust ESLint config for this project
    - Deviates much from Airbnb's rules, but that one is for frontends
      while this is a backend project
 * (all) ^remove eslint exceptions made unnecessary with the above change
 * (all) Prefer destructuring syntax, strip unneeded parens, 1000 -> 1e3
 * (all) const Id = function Id() -> function Id()
 * (all) Convert some ternaries into short circuits
 * (all) Reorder members of property descriptor object literals to match
   ECMA-262 9.0, section 6.2.5.4 FromPropertyDescriptor ( _Desc_ )
 * (all) Miscellaneous clean-ups
 * (index.js) hoist basic require()s to top
 * (lib/cache/driver/memory.js) Revert stable time to old impl. for
   consistency with the Redis cache backend
    - Partial undo of commit c807763c30b2f84c088ac4b65ca228a41b61e42a
 * (lib/controller/index.js) Controllers are now instantized
 * (lib/controller/library/pagination.js) escape into HTML entities
 * (lib/controller/library/session.js) use values from config directly
 * (lib/functions.js) New function: countSlashes()
 * (lib/loader.js) no duplicate name variations, no hasOwnProperty
 * (lib/misc/*_error.js) this.name in prototype, not on construction
 * (lib/model/engine.js) knexSelect: use / as /i, setPrototypeOf()
    - Performance impact of setPrototypeOf() should be minimal
      since we set prototype immediately upon creation of the function
 * (lib/router.js) Use the countSlashes() above
 * (lib/static/js/*) ES5-compatible code (not verified)
 * (test/example/controller/middleware/file/error{,2}/_.js)
   this.name in prototype, not on construction